### PR TITLE
Improve delete UX: edge deletion, right-click menu, node X button

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -71,7 +71,11 @@ html, body, #__nuxt {
   stroke-width: 2;
 }
 
-.vue-flow__edge.selected .vue-flow__edge-path,
+.vue-flow__edge.selected .vue-flow__edge-path {
+  stroke: #535DFF !important;
+  stroke-width: 3;
+}
+
 .vue-flow__edge:hover .vue-flow__edge-path {
   stroke: #888;
   stroke-width: 3;
@@ -91,6 +95,7 @@ html, body, #__nuxt {
   border: 2px solid #333;
 }
 
+
 .vue-flow__handle:hover {
   background: #aaa;
   border-color: #aaa;
@@ -98,6 +103,32 @@ html, body, #__nuxt {
 
 .vue-flow__handle-connecting {
   background: #aaa;
+}
+
+.vue-flow__edgeupdater {
+  r: 6;
+  fill: #555;
+  stroke: #333;
+  stroke-width: 2;
+  cursor: move;
+  opacity: 0;
+}
+
+.vue-flow__edges {
+  z-index: 3 !important;
+}
+
+.vue-flow__edgeupdater:hover {
+  fill: #aaa;
+  stroke: #aaa;
+}
+
+.vue-flow__edgeupdater-source {
+  transform: translateX(-12px);
+}
+
+.vue-flow__edgeupdater-target {
+  transform: translateX(12px);
 }
 
 /* Scrollbar styling */

--- a/app/components/TopBar.vue
+++ b/app/components/TopBar.vue
@@ -321,12 +321,19 @@ function handleKeyboard(e: KeyboardEvent) {
     if (store.isRunning) stop();
     else run();
   }
-  if (e.key === "Delete" || e.key === "Backspace") {
-    if (
-      store.selectedNodeId &&
-      !["INPUT", "TEXTAREA", "SELECT"].includes((e.target as Element)?.tagName)
-    ) {
+  if (
+    (e.key === "Delete" || e.key === "Backspace") &&
+    !["INPUT", "TEXTAREA", "SELECT"].includes((e.target as Element)?.tagName)
+  ) {
+    // Delete key removes selected node
+    if (e.key === "Delete" && store.selectedNodeId) {
+      e.preventDefault();
       store.removeNode(store.selectedNodeId);
+    }
+    // Both Delete and Backspace remove selected edge
+    if (store.selectedEdgeId) {
+      e.preventDefault();
+      store.removeEdge(store.selectedEdgeId);
     }
   }
 }

--- a/app/components/nodes/BaseNode.vue
+++ b/app/components/nodes/BaseNode.vue
@@ -28,6 +28,12 @@ const statusColor = computed(() => {
 
 const isSelected = computed(() => store.selectedNodeId === props.id)
 
+const isDeletable = computed(() => props.hasInput && props.hasOutput)
+
+function deleteNode() {
+  store.removeNode(props.id)
+}
+
 const borderColor = computed(() => {
   if (isSelected.value) return 'border-[#535DFF]'
   if (state.value.status === 'error') return 'border-red-500'
@@ -80,6 +86,16 @@ onUnmounted(() => {
         v-if="icon"
         class="w-3.5 h-3.5 text-gray-500 flex-shrink-0"
       />
+      <button
+        v-if="isSelected && isDeletable"
+        class="nodrag w-4 h-4 flex items-center justify-center rounded hover:bg-red-500/30 text-gray-500 hover:text-red-400 transition-colors flex-shrink-0"
+        title="Delete node"
+        @click.stop="deleteNode"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3 h-3">
+          <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+        </svg>
+      </button>
     </div>
 
     <!-- Output preview -->

--- a/app/stores/pipeline.ts
+++ b/app/stores/pipeline.ts
@@ -18,6 +18,7 @@ export const usePipelineStore = defineStore('pipeline', () => {
 
   // Selection
   const selectedNodeId = ref<string | null>(null)
+  const selectedEdgeId = ref<string | null>(null)
 
   // Execution state
   const isRunning = ref(false)
@@ -58,6 +59,26 @@ export const usePipelineStore = defineStore('pipeline', () => {
   // Actions
   function selectNode(nodeId: string | null) {
     selectedNodeId.value = nodeId
+    if (nodeId) selectedEdgeId.value = null
+  }
+
+  function selectEdge(edgeId: string | null) {
+    // Sync Vue Flow's selected state on edge objects
+    for (const e of edges.value) {
+      e.selected = e.id === edgeId
+    }
+    selectedEdgeId.value = edgeId
+    if (edgeId) selectedNodeId.value = null
+  }
+
+  function removeEdge(edgeId: string) {
+    const edge = edges.value.find(e => e.id === edgeId)
+    if (!edge) return
+    edges.value = edges.value.filter(e => e.id !== edgeId)
+    if (selectedEdgeId.value === edgeId) selectedEdgeId.value = null
+    isDirty.value = true
+    invalidateNode(edge.target)
+    invalidateDownstream(edge.target)
   }
 
   function getNodeState(nodeId: string): NodeState {
@@ -235,6 +256,7 @@ export const usePipelineStore = defineStore('pipeline', () => {
     fileName.value = null
     isDirty.value = false
     selectedNodeId.value = null
+    selectedEdgeId.value = null
     pipelineLoadCount.value++
   }
 
@@ -299,6 +321,7 @@ export const usePipelineStore = defineStore('pipeline', () => {
 
     isDirty.value = false
     selectedNodeId.value = null
+    selectedEdgeId.value = null
     pipelineLoadCount.value++
   }
 
@@ -331,6 +354,7 @@ export const usePipelineStore = defineStore('pipeline', () => {
     nodes,
     edges,
     selectedNodeId,
+    selectedEdgeId,
     isRunning,
     hasRun,
     nodeStates,
@@ -347,6 +371,8 @@ export const usePipelineStore = defineStore('pipeline', () => {
     outputImage,
     // Actions
     selectNode,
+    selectEdge,
+    removeEdge,
     getNodeState,
     updateNodeState,
     updateNodeParams,


### PR DESCRIPTION
## Summary
- Edge selection with mutual exclusion (selecting edge clears node and vice versa)
- Right-click edge → context menu with "Delete Edge"
- Drag-to-disconnect (drop on empty space) and drag-to-reconnect edges
- `Delete` key removes selected node; `Delete`/`Backspace` removes selected edge
- Selected edges highlight blue (matching node selection accent)
- X button on selected processing nodes for mouse-based deletion
- Edge updater anchors overlay connection handles (invisible, interactive)
- Context menus dismiss on canvas pan/zoom

## Test plan
- [x] Select a node, press `Delete` — node removed; `Backspace` does nothing
- [x] Click an edge to select it (turns blue), press `Delete` or `Backspace` — edge removed
- [x] Right-click an edge — "Delete Edge" context menu appears and works
- [x] Drag an edge endpoint to empty space — edge disconnects
- [x] Drag an edge endpoint to another valid handle — edge reconnects
- [x] X button visible on selected processing nodes, hidden on input/output
- [x] Context menus close when panning the canvas

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)