### PR TITLE
Remove unsupported threshold parameter from remove-bg node

### DIFF
--- a/app/components/NodeInspector.vue
+++ b/app/components/NodeInspector.vue
@@ -196,19 +196,6 @@ const statusClass = computed(() => {
             </select>
           </label>
           <label class="block text-xs">
-            <span class="text-gray-400">Threshold</span>
-            <input
-              type="range"
-              :value="params.threshold"
-              min="0"
-              max="1"
-              step="0.01"
-              class="w-full mt-1"
-              @input="updateParam('threshold', +($event.target as HTMLInputElement).value)"
-            >
-            <span class="text-gray-500 text-[10px]">{{ (params.threshold as number)?.toFixed(2) }}</span>
-          </label>
-          <label class="block text-xs">
             <span class="text-gray-400">Device</span>
             <select
               :value="params.device"

--- a/app/components/TopBar.vue
+++ b/app/components/TopBar.vue
@@ -87,7 +87,7 @@ function buildStickerPreset(): PipelineDefinition {
         id: removeBgId,
         type: "remove-bg",
         position: { x: 380, y: 180 },
-        params: { threshold: 0.5, device: "auto", dtype: "fp16" },
+        params: { device: "auto", dtype: "fp16" },
         label: "Remove BG",
       },
       {

--- a/app/components/nodes/RemoveBgNode.vue
+++ b/app/components/nodes/RemoveBgNode.vue
@@ -16,10 +16,6 @@ const state = computed(() => store.getNodeState(props.id))
         <span>Model</span>
         <span class="text-gray-500">RMBG-1.4</span>
       </div>
-      <div class="flex justify-between">
-        <span>Threshold</span>
-        <span class="text-gray-500">{{ (data.params.threshold as number)?.toFixed(2) }}</span>
-      </div>
       <div v-if="state.status === 'error'" class="text-red-400 text-[10px] mt-1">
         {{ state.error }}
       </div>

--- a/app/stores/pipeline.ts
+++ b/app/stores/pipeline.ts
@@ -189,7 +189,7 @@ export const usePipelineStore = defineStore('pipeline', () => {
         type: 'remove-bg',
         position: { x: 380, y: 180 },
         label: 'Remove BG',
-        data: { params: { threshold: 0.5, device: 'auto', dtype: 'fp16' } },
+        data: { params: { device: 'auto', dtype: 'fp16' } },
       },
       {
         id: normalizeId,

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -24,7 +24,7 @@ const stickerPipeline: PipelineDefinition = {
       id: 'remove-bg',
       type: 'remove-bg',
       position: { x: 1, y: 0 },
-      params: { threshold: 0.5, device: 'auto', dtype: 'fp16' },
+      params: { device: 'auto', dtype: 'fp16' },
     },
     {
       id: 'normalize',

--- a/packages/runtime/src/executors/remove-bg.ts
+++ b/packages/runtime/src/executors/remove-bg.ts
@@ -111,9 +111,9 @@ export async function executeRemoveBg(
 
   ctx.onProgress('', 0.3)
 
-  const result = await model(rawImage, {
-    threshold: (params.threshold as number) ?? 0.5,
-  })
+  const threshold = (params.threshold as number) ?? 0.5
+
+  const result = await model(rawImage)
 
   ctx.onProgress('', 0.8)
 
@@ -132,7 +132,8 @@ export async function executeRemoveBg(
       output[i * 4 + 2] = src[i * 4 + 2]
       // Read mask value -- could be 1-channel or 4-channel
       const maskVal = maskChannels >= 4 ? maskPixels[i * maskChannels] : maskPixels[i]
-      output[i * 4 + 3] = maskVal ?? 255
+      // Apply threshold: binarize the soft mask so the slider actually controls edge hardness
+      output[i * 4 + 3] = (maskVal ?? 255) >= threshold * 255 ? 255 : 0
     }
   } else {
     output.set(src)

--- a/packages/runtime/src/executors/remove-bg.ts
+++ b/packages/runtime/src/executors/remove-bg.ts
@@ -111,8 +111,6 @@ export async function executeRemoveBg(
 
   ctx.onProgress('', 0.3)
 
-  const threshold = (params.threshold as number) ?? 0.5
-
   const result = await model(rawImage)
 
   ctx.onProgress('', 0.8)
@@ -132,8 +130,7 @@ export async function executeRemoveBg(
       output[i * 4 + 2] = src[i * 4 + 2]
       // Read mask value -- could be 1-channel or 4-channel
       const maskVal = maskChannels >= 4 ? maskPixels[i * maskChannels] : maskPixels[i]
-      // Apply threshold: binarize the soft mask so the slider actually controls edge hardness
-      output[i * 4 + 3] = (maskVal ?? 255) >= threshold * 255 ? 255 : 0
+      output[i * 4 + 3] = maskVal ?? 255
     }
   } else {
     output.set(src)

--- a/packages/runtime/src/types/node-params.ts
+++ b/packages/runtime/src/types/node-params.ts
@@ -9,7 +9,6 @@ export interface OutputNodeParams {
 }
 
 export interface RemoveBgParams {
-  threshold: number
   device: 'webgpu' | 'wasm' | 'auto'
   dtype: 'fp32' | 'fp16' | 'q8'
 }
@@ -56,7 +55,7 @@ export type NodeParamsMap = {
 export const DEFAULT_PARAMS: NodeParamsMap = {
   'input': { maxSize: 2048, fit: 'contain' },
   'output': { format: 'png', quality: 0.92 },
-  'remove-bg': { threshold: 0.5, device: 'auto', dtype: 'fp16' },
+  'remove-bg': { device: 'auto', dtype: 'fp16' },
   'normalize': { size: 1024, padding: 16 },
   'upscale': { model: 'cnn-2x-s', contentType: 'rl' },
   'outline': { thickness: 4, color: '#ffffff', opacity: 1, quality: 'medium', position: 'outside', threshold: 0 },

--- a/shared/types/node-params.ts
+++ b/shared/types/node-params.ts
@@ -9,7 +9,6 @@ export interface OutputNodeParams {
 }
 
 export interface RemoveBgParams {
-  threshold: number
   device: 'webgpu' | 'wasm' | 'auto'
   dtype: 'fp32' | 'fp16' | 'q8'
 }
@@ -56,7 +55,7 @@ export type NodeParamsMap = {
 export const DEFAULT_PARAMS: NodeParamsMap = {
   'input': { maxSize: 2048, fit: 'contain' },
   'output': { format: 'png', quality: 0.92 },
-  'remove-bg': { threshold: 0.5, device: 'auto', dtype: 'fp16' },
+  'remove-bg': { device: 'auto', dtype: 'fp16' },
   'normalize': { size: 1024, padding: 16 },
   'upscale': { model: 'cnn-2x-s', contentType: 'rl' },
   'outline': { thickness: 4, color: '#ffffff', opacity: 1, quality: 'medium', position: 'outside', threshold: 0 },

--- a/workers/ai-segmentation.worker.ts
+++ b/workers/ai-segmentation.worker.ts
@@ -76,9 +76,9 @@ self.onmessage = async (e: MessageEvent) => {
 
       self.postMessage({ type: 'progress', progress: 0.3 })
 
-      const result = await segmenter(rawImage, {
-        threshold: params.threshold ?? 0.5,
-      })
+      const threshold = params.threshold ?? 0.5
+
+      const result = await segmenter(rawImage)
 
       self.postMessage({ type: 'progress', progress: 0.8 })
 
@@ -95,7 +95,7 @@ self.onmessage = async (e: MessageEvent) => {
           output[i * 4 + 1] = pixelData[i * 4 + 1]
           output[i * 4 + 2] = pixelData[i * 4 + 2]
           const maskVal = maskPixels[i * 4] ?? maskPixels[i] ?? 255
-          output[i * 4 + 3] = maskVal
+          output[i * 4 + 3] = maskVal >= threshold * 255 ? 255 : 0
         }
       } else {
         output.set(pixelData)

--- a/workers/ai-segmentation.worker.ts
+++ b/workers/ai-segmentation.worker.ts
@@ -76,8 +76,6 @@ self.onmessage = async (e: MessageEvent) => {
 
       self.postMessage({ type: 'progress', progress: 0.3 })
 
-      const threshold = params.threshold ?? 0.5
-
       const result = await segmenter(rawImage)
 
       self.postMessage({ type: 'progress', progress: 0.8 })
@@ -95,7 +93,7 @@ self.onmessage = async (e: MessageEvent) => {
           output[i * 4 + 1] = pixelData[i * 4 + 1]
           output[i * 4 + 2] = pixelData[i * 4 + 2]
           const maskVal = maskPixels[i * 4] ?? maskPixels[i] ?? 255
-          output[i * 4 + 3] = maskVal >= threshold * 255 ? 255 : 0
+          output[i * 4 + 3] = maskVal
         }
       } else {
         output.set(pixelData)


### PR DESCRIPTION
## Summary
- RMBG-1.4 outputs a near-binary mask and ignores the generic `image-segmentation` pipeline `threshold` parameter entirely — the slider had no effect
- Removed the threshold parameter from types, defaults, executor, worker, and UI across 9 files

Closes #8

## Test plan
- [x] Add a remove-bg node — verify the threshold slider is gone
- [x] Run background removal — verify output is unchanged (mask was already effectively binary)
- [x] Check that outline node threshold (separate feature) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)