### PR TITLE
Do not use cached yarn in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: yarn
       - run: corepack enable
       - run: yarn install --immutable
 


### PR DESCRIPTION
`cache: yarn` causes CI to fail, because it uses image with global Yarn 1.22.22