### PR TITLE
Multi-link nodes, canvas UX improvements, and spritesheet node

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ const result = await pm.run(
 - **Estimate Depth** — Monocular depth estimation using [Depth Anything V2](https://huggingface.co/onnx-community/depth-anything-v2-small) via Transformers.js (WebGPU / WASM). Fast (~25 MB) and Quality (~40 MB) modes
 - **Face Parse** — Face segmentation into 19 classes (skin, eyes, hair, etc.) using [face-parsing](https://huggingface.co/Xenova/face-parsing) via Transformers.js (WebGPU / WASM). Outputs a color-coded segmentation map
 - **Upscale 2x** — Super-resolution with [WebSR](https://github.com/nicknbytes/websr) (Anime4K CNN models)
+- **Spritesheet** — Composite multiple images into a grid spritesheet with configurable columns, rows, gap, and background color. Outputs UV-mapped frame data for game engines
 - **Output** — Encode to PNG / JPEG / WebP
 
 ## Packages

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ import { PipeMagic } from "pipemagic";
 const pm = new PipeMagic();
 const result = await pm.run(
   pipeline, // create these with the Node Editor
-  imageFile,
+  imageFile, // or { "Input 1": file1, "Input 2": file2 } for multi-input pipelines
 );
 // result.blob → output PNG
+// result.outputs → all outputs keyed by label
 ```
 
 ## Supported Nodes

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -37,6 +37,15 @@ html, body, #__nuxt {
   padding: 0 !important;
 }
 
+.vue-flow__selection {
+  background: rgba(83, 93, 255, 0.08);
+  border: 1px solid rgba(83, 93, 255, 0.4);
+}
+
+.vue-flow__nodesselection {
+  display: none !important;
+}
+
 .vue-flow__minimap {
   background: #1a1a1a !important;
   border: 1px solid #333;

--- a/app/components/NodeInspector.vue
+++ b/app/components/NodeInspector.vue
@@ -14,10 +14,10 @@ const nodeType = computed(() => node.value?.type as NodeType | undefined)
 const previewUrl = ref<string | null>(null)
 const isZoomed = ref(false)
 
-watch(() => state.value?.output, async (output) => {
+watch(() => state.value?.output?.asset, async (asset) => {
   if (previewUrl.value) URL.revokeObjectURL(previewUrl.value)
-  if (output?.bitmap) {
-    const blob = await bitmapToBlob(output.bitmap, 'png')
+  if (asset?.bitmap) {
+    const blob = await bitmapToBlob(asset.bitmap, 'png')
     previewUrl.value = URL.createObjectURL(blob)
   } else {
     previewUrl.value = null
@@ -90,8 +90,8 @@ const statusClass = computed(() => {
           >
             <span class="text-[10px] text-gray-600">No output</span>
           </div>
-          <div v-if="state?.output" class="text-[10px] text-gray-500 mt-1">
-            {{ state.output.width }} &times; {{ state.output.height }}
+          <div v-if="state?.output?.asset" class="text-[10px] text-gray-500 mt-1">
+            {{ state.output.asset.width }} &times; {{ state.output.asset.height }}
           </div>
         </div>
       </div>
@@ -117,6 +117,12 @@ const statusClass = computed(() => {
         <div v-if="state?.deviceUsed" class="mt-1 text-[10px] text-gray-500">
           Device: {{ state.deviceUsed }}
         </div>
+      </div>
+
+      <!-- Data output (e.g. spritesheet UV data) -->
+      <div v-if="state?.output?.data" class="p-3 border-b border-gray-800">
+        <div class="text-[10px] text-gray-500 font-semibold uppercase tracking-wider mb-2">Data Output</div>
+        <pre class="text-[10px] text-gray-400 bg-gray-800 rounded p-2 overflow-auto max-h-[200px] whitespace-pre-wrap break-all">{{ JSON.stringify(state.output.data, null, 2) }}</pre>
       </div>
 
       <!-- Parameters -->
@@ -306,6 +312,57 @@ const statusClass = computed(() => {
               <option value="auto">Auto</option>
               <option value="webgpu">WebGPU</option>
               <option value="wasm">WASM</option>
+            </select>
+          </label>
+        </template>
+
+        <!-- Spritesheet params -->
+        <template v-if="nodeType === 'spritesheet' && params">
+          <label class="block text-xs">
+            <span class="text-gray-400">Columns</span>
+            <select
+              :value="params.columns"
+              class="w-full mt-1 bg-gray-800 border border-gray-700 rounded px-2 py-1 text-gray-300 text-xs"
+              @change="updateParam('columns', ($event.target as HTMLSelectElement).value === 'auto' ? 'auto' : +($event.target as HTMLSelectElement).value)"
+            >
+              <option value="auto">Auto</option>
+              <option v-for="n in 12" :key="n" :value="n">{{ n }}</option>
+            </select>
+          </label>
+          <label class="block text-xs">
+            <span class="text-gray-400">Rows</span>
+            <select
+              :value="params.rows"
+              class="w-full mt-1 bg-gray-800 border border-gray-700 rounded px-2 py-1 text-gray-300 text-xs"
+              @change="updateParam('rows', ($event.target as HTMLSelectElement).value === 'auto' ? 'auto' : +($event.target as HTMLSelectElement).value)"
+            >
+              <option value="auto">Auto</option>
+              <option v-for="n in 12" :key="n" :value="n">{{ n }}</option>
+            </select>
+          </label>
+          <label class="block text-xs">
+            <span class="text-gray-400">Gap</span>
+            <input
+              type="range"
+              :value="params.gap"
+              min="0"
+              max="64"
+              step="1"
+              class="w-full mt-1"
+              @input="updateParam('gap', +($event.target as HTMLInputElement).value)"
+            >
+            <span class="text-gray-500 text-[10px]">{{ params.gap }}px</span>
+          </label>
+          <label class="block text-xs">
+            <span class="text-gray-400">Background</span>
+            <select
+              :value="params.bgColor"
+              class="w-full mt-1 bg-gray-800 border border-gray-700 rounded px-2 py-1 text-gray-300 text-xs"
+              @change="updateParam('bgColor', ($event.target as HTMLSelectElement).value)"
+            >
+              <option value="transparent">Transparent</option>
+              <option value="#000000">Black</option>
+              <option value="#ffffff">White</option>
             </select>
           </label>
         </template>

--- a/app/components/PipelineCanvas.vue
+++ b/app/components/PipelineCanvas.vue
@@ -23,7 +23,7 @@ import {
   TrashIcon,
 } from "@heroicons/vue/20/solid";
 import { usePipelineStore } from "~/stores/pipeline";
-import { getHandleDefs } from "pipemagic";
+import { getHandleDefs, fileToBitmap, resizeBitmap } from "pipemagic";
 import type { NodeType } from "~~/shared/types/pipeline";
 import type { Connection } from "@vue-flow/core";
 
@@ -333,10 +333,66 @@ watch(
     });
   },
 );
+
+// Canvas-level multi-file drop handler
+async function onCanvasDrop(e: DragEvent) {
+  e.preventDefault();
+  // Don't handle drops that land on a node — let the node's own handler deal with it
+  if ((e.target as HTMLElement).closest(".vue-flow__node")) return;
+
+  const files = [...(e.dataTransfer?.files || [])].filter((f) =>
+    f.type.startsWith("image/"),
+  );
+  if (!files.length) return;
+
+  // Get existing input nodes sorted by vertical position (top → bottom)
+  const inputNodes = store.nodes
+    .filter((n: any) => n.type === "input")
+    .sort((a: any, b: any) => a.position.y - b.position.y);
+
+  // Build assignment list: pair each file with a node ID
+  // Assign to existing inputs first, then create new nodes for overflow
+  const assignments: { nodeId: string; file: File }[] = [];
+  for (let i = 0; i < files.length; i++) {
+    let nodeId: string;
+    if (i < inputNodes.length) {
+      nodeId = inputNodes[i].id;
+    } else {
+      const refNode =
+        inputNodes[inputNodes.length - 1] ||
+        store.nodes[store.nodes.length - 1];
+      const refPos = refNode
+        ? refNode.position
+        : { x: 60, y: -20 };
+      const yOffset = 200 * (i - inputNodes.length + 1);
+      nodeId = store.addNode("input", {
+        x: refPos.x,
+        y: refPos.y + yOffset,
+      });
+    }
+    assignments.push({ nodeId, file: files[i] });
+  }
+
+  // Process all files → load images into the assigned nodes
+  for (const { nodeId, file } of assignments) {
+    const node = store.nodes.find((n: any) => n.id === nodeId);
+    const params = (node?.data as any)?.params || {};
+    const bitmap = await fileToBitmap(file);
+    const maxSize = (params.maxSize as number) || 2048;
+    const fit = (params.fit as "contain" | "cover" | "fill") || "contain";
+    const resized = await resizeBitmap(bitmap, maxSize, fit);
+    store.setInputImage(nodeId, {
+      bitmap: resized,
+      width: resized.width,
+      height: resized.height,
+      revision: Date.now(),
+    });
+  }
+}
 </script>
 
 <template>
-  <div ref="containerRef" class="w-full h-full" @click="closeContextMenu" @contextmenu.prevent="onCanvasContextMenu">
+  <div ref="containerRef" class="w-full h-full" @click="closeContextMenu" @contextmenu.prevent="onCanvasContextMenu" @dragover.prevent @drop="onCanvasDrop">
     <VueFlow
       v-model:nodes="store.nodes"
       v-model:edges="store.edges"

--- a/app/components/PipelineCanvas.vue
+++ b/app/components/PipelineCanvas.vue
@@ -11,7 +11,9 @@ import { markRaw } from "vue";
 import { nanoid } from "nanoid";
 import { useElementSize } from "@vueuse/core";
 import { usePipelineStore } from "~/stores/pipeline";
+import { getHandleDefs } from "pipemagic";
 import type { NodeType } from "~~/shared/types/pipeline";
+import type { Connection } from "@vue-flow/core";
 
 import InputNode from "~/components/nodes/InputNode.vue";
 import OutputNode from "~/components/nodes/OutputNode.vue";
@@ -21,6 +23,7 @@ import NormalizeNode from "~/components/nodes/NormalizeNode.vue";
 import OutlineNode from "~/components/nodes/OutlineNode.vue";
 import DepthNode from "~/components/nodes/DepthNode.vue";
 import FaceParseNode from "~/components/nodes/FaceParseNode.vue";
+import SpritesheetNode from "~/components/nodes/SpritesheetNode.vue";
 
 const nodeTypes = {
   input: markRaw(InputNode),
@@ -31,6 +34,7 @@ const nodeTypes = {
   outline: markRaw(OutlineNode),
   depth: markRaw(DepthNode),
   "face-parse": markRaw(FaceParseNode),
+  spritesheet: markRaw(SpritesheetNode),
 };
 
 const store = usePipelineStore();
@@ -59,6 +63,7 @@ const {
   onEdgeUpdate,
   onEdgeUpdateEnd,
   onMoveStart,
+  addEdges,
   project,
   setCenter,
   getViewport,
@@ -81,13 +86,27 @@ onPaneClick(() => {
 
 // Handle new connections
 onConnect((connection) => {
-  store.edges.push({
-    id: nanoid(8),
-    source: connection.source,
-    sourceHandle: connection.sourceHandle || "output",
-    target: connection.target,
-    targetHandle: connection.targetHandle || "input",
-  } as any);
+  if (!connection.source || !connection.target) return;
+  // Prevent duplicate connections to the same non-multi target handle
+  const targetHandleId = connection.targetHandle || "asset";
+  const exists = store.edges.some(
+    (e: any) =>
+      e.source === connection.source &&
+      e.sourceHandle === (connection.sourceHandle || "asset") &&
+      e.target === connection.target &&
+      e.targetHandle === targetHandleId,
+  );
+  if (exists) return;
+
+  addEdges([
+    {
+      id: nanoid(8),
+      source: connection.source,
+      sourceHandle: connection.sourceHandle || "asset",
+      target: connection.target,
+      targetHandle: connection.targetHandle || "asset",
+    },
+  ]);
   store.isDirty = true;
 });
 
@@ -131,9 +150,9 @@ onEdgeUpdate(({ edge, connection }) => {
   store.edges.push({
     id: nanoid(8),
     source: connection.source,
-    sourceHandle: connection.sourceHandle || "output",
+    sourceHandle: connection.sourceHandle || "asset",
     target: connection.target,
-    targetHandle: connection.targetHandle || "input",
+    targetHandle: connection.targetHandle || "asset",
   } as any);
   store.isDirty = true;
 });
@@ -144,6 +163,36 @@ onEdgeUpdateEnd(({ edge }) => {
   }
 });
 
+// Connection validation: check data type compatibility
+function isValidConnection(connection: Connection) {
+  const sourceNode = store.nodes.find((n: any) => n.id === connection.source);
+  const targetNode = store.nodes.find((n: any) => n.id === connection.target);
+  if (!sourceNode || !targetNode) return false;
+
+  const sourceDefs = getHandleDefs(sourceNode.type as NodeType);
+  const targetDefs = getHandleDefs(targetNode.type as NodeType);
+
+  const sourceHandle = sourceDefs.sources.find(
+    (h) => h.id === (connection.sourceHandle || "asset"),
+  );
+  const targetHandle = targetDefs.targets.find(
+    (h) => h.id === (connection.targetHandle || "asset"),
+  );
+
+  if (!sourceHandle || !targetHandle) return false;
+  if (sourceHandle.dataType !== targetHandle.dataType) return false;
+
+  // Block multiple connections to the same non-multi target handle
+  if (!targetHandle.multi) {
+    const targetHandleId = connection.targetHandle || "asset";
+    const alreadyConnected = store.edges.some(
+      (e: any) => e.target === connection.target && e.targetHandle === targetHandleId,
+    );
+    if (alreadyConnected) return false;
+  }
+
+  return true;
+}
 // Context menu for adding nodes
 const contextMenu = ref<{ x: number; y: number; show: boolean }>({
   x: 0,
@@ -152,12 +201,15 @@ const contextMenu = ref<{ x: number; y: number; show: boolean }>({
 });
 
 const addableNodes: { type: NodeType; label: string }[] = [
+  { type: "input", label: "Image Input" },
+  { type: "output", label: "Output" },
   { type: "remove-bg", label: "Remove BG" },
   { type: "normalize", label: "Normalize" },
   { type: "outline", label: "Outline" },
   { type: "upscale", label: "Upscale 2x" },
   { type: "depth", label: "Estimate Depth" },
   { type: "face-parse", label: "Face Parse" },
+  { type: "spritesheet", label: "Spritesheet" },
 ];
 
 function onPaneContextMenu(event: MouseEvent) {
@@ -231,6 +283,7 @@ watch(
       :max-zoom="2"
       :edges-updatable="true"
       :delete-key-code="null"
+      :is-valid-connection="isValidConnection"
       fit-view-on-init
       @pane-contextmenu="onPaneContextMenu"
     >

--- a/app/components/PipelineCanvas.vue
+++ b/app/components/PipelineCanvas.vue
@@ -10,6 +10,18 @@ import "@vue-flow/minimap/dist/style.css";
 import { markRaw } from "vue";
 import { nanoid } from "nanoid";
 import { useElementSize } from "@vueuse/core";
+import {
+  PhotoIcon,
+  ArrowDownTrayIcon,
+  ScissorsIcon,
+  ArrowsPointingInIcon,
+  ArrowsPointingOutIcon,
+  PaintBrushIcon,
+  EyeIcon,
+  UserIcon,
+  Squares2X2Icon,
+  TrashIcon,
+} from "@heroicons/vue/20/solid";
 import { usePipelineStore } from "~/stores/pipeline";
 import { getHandleDefs } from "pipemagic";
 import type { NodeType } from "~~/shared/types/pipeline";
@@ -55,6 +67,7 @@ const minimapH = computed(() => {
 
 const {
   onNodeClick,
+  onNodeContextMenu,
   onPaneClick,
   onConnect,
   onEdgeClick,
@@ -63,7 +76,6 @@ const {
   onEdgeUpdate,
   onEdgeUpdateEnd,
   onMoveStart,
-  addEdges,
   project,
   setCenter,
   getViewport,
@@ -87,26 +99,16 @@ onPaneClick(() => {
 // Handle new connections
 onConnect((connection) => {
   if (!connection.source || !connection.target) return;
-  // Prevent duplicate connections to the same non-multi target handle
-  const targetHandleId = connection.targetHandle || "asset";
-  const exists = store.edges.some(
-    (e: any) =>
-      e.source === connection.source &&
-      e.sourceHandle === (connection.sourceHandle || "asset") &&
-      e.target === connection.target &&
-      e.targetHandle === targetHandleId,
-  );
-  if (exists) return;
+  // Validate connection before adding
+  if (!isValidConnection(connection)) return;
 
-  addEdges([
-    {
-      id: nanoid(8),
-      source: connection.source,
-      sourceHandle: connection.sourceHandle || "asset",
-      target: connection.target,
-      targetHandle: connection.targetHandle || "asset",
-    },
-  ]);
+  store.edges.push({
+    id: nanoid(8),
+    source: connection.source,
+    sourceHandle: connection.sourceHandle || "asset",
+    target: connection.target,
+    targetHandle: connection.targetHandle || "asset",
+  } as any);
   store.isDirty = true;
 });
 
@@ -128,11 +130,30 @@ function deleteEdgeFromMenu() {
   edgeContextMenu.value.show = false;
 }
 
-// Close edge context menu when selection changes
+// Node context menu (right-click)
+const nodeContextMenu = ref<{ x: number; y: number; nodeId: string; show: boolean }>({
+  x: 0,
+  y: 0,
+  nodeId: "",
+  show: false,
+});
+
+onNodeContextMenu(({ event, node }) => {
+  event.preventDefault();
+  nodeContextMenu.value = { x: event.clientX, y: event.clientY, nodeId: node.id, show: true };
+});
+
+function deleteNodeFromMenu() {
+  store.removeNode(nodeContextMenu.value.nodeId);
+  nodeContextMenu.value.show = false;
+}
+
+// Close context menus when selection changes
 watch(
   () => [store.selectedNodeId, store.selectedEdgeId],
   () => {
     edgeContextMenu.value.show = false;
+    nodeContextMenu.value.show = false;
   },
 );
 
@@ -200,20 +221,27 @@ const contextMenu = ref<{ x: number; y: number; show: boolean }>({
   show: false,
 });
 
-const addableNodes: { type: NodeType; label: string }[] = [
-  { type: "input", label: "Image Input" },
-  { type: "output", label: "Output" },
-  { type: "remove-bg", label: "Remove BG" },
-  { type: "normalize", label: "Normalize" },
-  { type: "outline", label: "Outline" },
-  { type: "upscale", label: "Upscale 2x" },
-  { type: "depth", label: "Estimate Depth" },
-  { type: "face-parse", label: "Face Parse" },
-  { type: "spritesheet", label: "Spritesheet" },
+const addableNodes: { type: NodeType; label: string; icon: Component; separator?: boolean }[] = [
+  { type: "input", label: "Image Input", icon: PhotoIcon },
+  { type: "output", label: "Output", icon: ArrowDownTrayIcon },
+  { type: "remove-bg", label: "Remove BG", icon: ScissorsIcon, separator: true },
+  { type: "normalize", label: "Normalize", icon: ArrowsPointingInIcon },
+  { type: "outline", label: "Outline", icon: PaintBrushIcon },
+  { type: "upscale", label: "Upscale 2x", icon: ArrowsPointingOutIcon },
+  { type: "depth", label: "Estimate Depth", icon: EyeIcon },
+  { type: "face-parse", label: "Face Parse", icon: UserIcon },
+  { type: "spritesheet", label: "Spritesheet", icon: Squares2X2Icon },
 ];
 
 function onPaneContextMenu(event: MouseEvent) {
   event.preventDefault();
+  contextMenu.value = { x: event.clientX, y: event.clientY, show: true };
+}
+
+function onCanvasContextMenu(event: MouseEvent) {
+  // Only show add-node menu if not clicking on a node or edge (those have their own menus)
+  const target = event.target as HTMLElement;
+  if (target.closest('.vue-flow__node') || target.closest('.vue-flow__edge')) return;
   contextMenu.value = { x: event.clientX, y: event.clientY, show: true };
 }
 
@@ -226,6 +254,23 @@ function addNodeFromMenu(type: NodeType) {
 function closeContextMenu() {
   contextMenu.value.show = false;
   edgeContextMenu.value.show = false;
+  nodeContextMenu.value.show = false;
+}
+
+// Position context menus so they don't overflow the viewport
+function menuStyle(x: number, y: number) {
+  const style: Record<string, string> = { position: 'fixed', left: `${x}px`, top: `${y}px` }
+  // Flip upward if near bottom (estimate ~300px max menu height)
+  if (y + 300 > window.innerHeight) {
+    style.top = ''
+    style.bottom = `${window.innerHeight - y}px`
+  }
+  // Flip left if near right edge
+  if (x + 200 > window.innerWidth) {
+    style.left = ''
+    style.right = `${window.innerWidth - x}px`
+  }
+  return style
 }
 
 onMoveStart(closeContextMenu);
@@ -271,7 +316,7 @@ watch(
 </script>
 
 <template>
-  <div ref="containerRef" class="w-full h-full" @click="closeContextMenu">
+  <div ref="containerRef" class="w-full h-full" @click="closeContextMenu" @contextmenu.prevent="onCanvasContextMenu">
     <VueFlow
       v-model:nodes="store.nodes"
       v-model:edges="store.edges"
@@ -283,7 +328,6 @@ watch(
       :max-zoom="2"
       :edges-updatable="true"
       :delete-key-code="null"
-      :is-valid-connection="isValidConnection"
       fit-view-on-init
       @pane-contextmenu="onPaneContextMenu"
     >
@@ -302,22 +346,21 @@ watch(
     <Teleport to="body">
       <div
         v-if="contextMenu.show"
-        class="fixed z-50 bg-gray-1200 border border-gray-700 rounded-lg shadow-xl py-1 min-w-[160px]"
-        :style="{ left: `${contextMenu.x}px`, top: `${contextMenu.y}px` }"
+        class="z-50 bg-gray-900 border border-gray-700 rounded-lg shadow-xl py-1 min-w-[180px]"
+        :style="menuStyle(contextMenu.x, contextMenu.y)"
+        @click.stop
       >
-        <div
-          class="px-3 py-1.5 text-[10px] text-gray-500 font-semibold uppercase tracking-wider"
-        >
-          Add Node
-        </div>
-        <button
-          v-for="node in addableNodes"
-          :key="node.type"
-          class="w-full text-left px-3 py-1.5 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors"
-          @click.stop="addNodeFromMenu(node.type)"
-        >
-          {{ node.label }}
-        </button>
+        <template v-for="(node, i) in addableNodes" :key="node.type">
+          <div v-if="node.separator" class="h-px bg-gray-700 my-1" />
+          <button
+            class="w-full text-left mx-1 px-2 py-1.5 text-xs text-gray-300 hover:bg-gray-800/80 hover:text-white rounded-md transition-colors flex items-center gap-2"
+            style="width: calc(100% - 0.5rem)"
+            @click.stop="addNodeFromMenu(node.type)"
+          >
+            <component :is="node.icon" class="w-3.5 h-3.5 text-gray-500 flex-shrink-0" />
+            <span class="flex-1">{{ node.label }}</span>
+          </button>
+        </template>
       </div>
     </Teleport>
 
@@ -325,15 +368,36 @@ watch(
     <Teleport to="body">
       <div
         v-if="edgeContextMenu.show"
-        class="fixed z-50 bg-gray-900 border border-gray-700 rounded-lg shadow-xl py-1 min-w-[140px]"
-        :style="{ left: `${edgeContextMenu.x}px`, top: `${edgeContextMenu.y}px` }"
+        class="z-50 bg-gray-900 border border-gray-700 rounded-lg shadow-xl py-1 min-w-[180px]"
+        :style="menuStyle(edgeContextMenu.x, edgeContextMenu.y)"
         @click.stop
       >
         <button
-          class="w-full text-left px-3 py-1.5 text-sm text-red-400 hover:bg-gray-700 hover:text-red-300 transition-colors"
+          class="w-full text-left mx-1 px-2 py-1.5 text-xs text-red-400 hover:bg-gray-800/80 hover:text-red-300 rounded-md transition-colors flex items-center gap-2"
+          style="width: calc(100% - 0.5rem)"
           @click.stop="deleteEdgeFromMenu"
         >
-          Delete Edge
+          <TrashIcon class="w-3.5 h-3.5 flex-shrink-0" />
+          <span class="flex-1">Delete Edge</span>
+        </button>
+      </div>
+    </Teleport>
+
+    <!-- Node context menu -->
+    <Teleport to="body">
+      <div
+        v-if="nodeContextMenu.show"
+        class="z-50 bg-gray-900 border border-gray-700 rounded-lg shadow-xl py-1 min-w-[180px]"
+        :style="menuStyle(nodeContextMenu.x, nodeContextMenu.y)"
+        @click.stop
+      >
+        <button
+          class="w-full text-left mx-1 px-2 py-1.5 text-xs text-red-400 hover:bg-gray-800/80 hover:text-red-300 rounded-md transition-colors flex items-center gap-2"
+          style="width: calc(100% - 0.5rem)"
+          @click.stop="deleteNodeFromMenu"
+        >
+          <TrashIcon class="w-3.5 h-3.5 flex-shrink-0" />
+          <span class="flex-1">Delete Node</span>
         </button>
       </div>
     </Teleport>

--- a/app/components/PipelineCanvas.vue
+++ b/app/components/PipelineCanvas.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { VueFlow, useVueFlow } from "@vue-flow/core";
+import { VueFlow, useVueFlow, SelectionMode } from "@vue-flow/core";
 import { Background } from "@vue-flow/background";
 import { Controls } from "@vue-flow/controls";
 import { MiniMap } from "@vue-flow/minimap";
@@ -79,12 +79,19 @@ const {
   project,
   setCenter,
   getViewport,
+  getSelectedNodes,
   fitView,
 } = useVueFlow();
 
-// Sync selection
-onNodeClick(({ node }) => {
-  store.selectNode(node.id);
+// Sync Vue Flow selection → store
+watch(getSelectedNodes, (selectedNodes) => {
+  store.selectedNodeIds = selectedNodes.map((n) => n.id);
+  if (selectedNodes.length > 0) store.selectEdge(null);
+});
+
+onNodeClick(() => {
+  // Clear edge selection when a node is clicked; Vue Flow handles node selection
+  store.selectEdge(null);
 });
 
 onEdgeClick(({ edge }) => {
@@ -92,7 +99,6 @@ onEdgeClick(({ edge }) => {
 });
 
 onPaneClick(() => {
-  store.selectNode(null);
   store.selectEdge(null);
 });
 
@@ -140,17 +146,31 @@ const nodeContextMenu = ref<{ x: number; y: number; nodeId: string; show: boolea
 
 onNodeContextMenu(({ event, node }) => {
   event.preventDefault();
+  // If the right-clicked node isn't in the current selection, make it the sole selection
+  if (!store.selectedNodeIds.includes(node.id)) {
+    for (const n of store.nodes) n.selected = n.id === node.id;
+    store.selectedNodeIds = [node.id];
+  }
   nodeContextMenu.value = { x: event.clientX, y: event.clientY, nodeId: node.id, show: true };
 });
 
+const nodeContextMenuLabel = computed(() => {
+  const count = store.selectedNodeIds.length;
+  return count > 1 ? `Delete ${count} Nodes` : "Delete Node";
+});
+
 function deleteNodeFromMenu() {
-  store.removeNode(nodeContextMenu.value.nodeId);
+  if (store.selectedNodeIds.length > 1) {
+    store.removeSelectedNodes();
+  } else {
+    store.removeNode(nodeContextMenu.value.nodeId);
+  }
   nodeContextMenu.value.show = false;
 }
 
 // Close context menus when selection changes
 watch(
-  () => [store.selectedNodeId, store.selectedEdgeId],
+  () => [store.selectedNodeIds, store.selectedEdgeId],
   () => {
     edgeContextMenu.value.show = false;
     nodeContextMenu.value.show = false;
@@ -328,6 +348,9 @@ watch(
       :max-zoom="2"
       :edges-updatable="true"
       :delete-key-code="null"
+      :multi-selection-key-code="'Shift'"
+      :selection-key-code="'Shift'"
+      :selection-mode="SelectionMode.Partial"
       fit-view-on-init
       @pane-contextmenu="onPaneContextMenu"
     >
@@ -397,7 +420,7 @@ watch(
           @click.stop="deleteNodeFromMenu"
         >
           <TrashIcon class="w-3.5 h-3.5 flex-shrink-0" />
-          <span class="flex-1">Delete Node</span>
+          <span class="flex-1">{{ nodeContextMenuLabel }}</span>
         </button>
       </div>
     </Teleport>

--- a/app/components/TopBar.vue
+++ b/app/components/TopBar.vue
@@ -5,6 +5,7 @@ import {
   FolderOpenIcon,
   ArrowDownTrayIcon,
   DocumentDuplicateIcon,
+  PhotoIcon,
   ScissorsIcon,
   ArrowsPointingInIcon,
   ArrowsPointingOutIcon,
@@ -12,6 +13,7 @@ import {
   SparklesIcon,
   EyeIcon,
   UserIcon,
+  Squares2X2Icon,
 } from "@heroicons/vue/20/solid";
 import type { NodeType } from "~~/shared/types/pipeline";
 import { usePipelineStore } from "~/stores/pipeline";
@@ -130,37 +132,37 @@ function buildStickerPreset(): PipelineDefinition {
       {
         id: nanoid(8),
         source: inputId,
-        sourceHandle: "output",
+        sourceHandle: "asset",
         target: removeBgId,
-        targetHandle: "input",
+        targetHandle: "asset",
       },
       {
         id: nanoid(8),
         source: removeBgId,
-        sourceHandle: "output",
+        sourceHandle: "asset",
         target: normalizeId,
-        targetHandle: "input",
+        targetHandle: "asset",
       },
       {
         id: nanoid(8),
         source: normalizeId,
-        sourceHandle: "output",
+        sourceHandle: "asset",
         target: outlineId,
-        targetHandle: "input",
+        targetHandle: "asset",
       },
       {
         id: nanoid(8),
         source: outlineId,
-        sourceHandle: "output",
+        sourceHandle: "asset",
         target: upscaleId,
-        targetHandle: "input",
+        targetHandle: "asset",
       },
       {
         id: nanoid(8),
         source: upscaleId,
-        sourceHandle: "output",
+        sourceHandle: "asset",
         target: outputId,
-        targetHandle: "input",
+        targetHandle: "asset",
       },
     ],
   };
@@ -233,16 +235,16 @@ function buildDepthMapPreset(): PipelineDefinition {
       {
         id: nanoid(8),
         source: inputId,
-        sourceHandle: "output",
+        sourceHandle: "asset",
         target: depthId,
-        targetHandle: "input",
+        targetHandle: "asset",
       },
       {
         id: nanoid(8),
         source: depthId,
-        sourceHandle: "output",
+        sourceHandle: "asset",
         target: outputId,
-        targetHandle: "input",
+        targetHandle: "asset",
       },
     ],
   };
@@ -274,6 +276,17 @@ function addNodeAtCenter(type: NodeType) {
 
 const addNodeItems = computed<MenuItem[]>(() => [
   {
+    label: "Image Input",
+    icon: PhotoIcon,
+    action: () => addNodeAtCenter("input"),
+  },
+  {
+    label: "Output",
+    icon: ArrowDownTrayIcon,
+    action: () => addNodeAtCenter("output"),
+  },
+  { separator: true, label: "" },
+  {
     label: "Remove BG",
     icon: ScissorsIcon,
     action: () => addNodeAtCenter("remove-bg"),
@@ -302,6 +315,11 @@ const addNodeItems = computed<MenuItem[]>(() => [
     label: "Face Parse",
     icon: UserIcon,
     action: () => addNodeAtCenter("face-parse"),
+  },
+  {
+    label: "Spritesheet",
+    icon: Squares2X2Icon,
+    action: () => addNodeAtCenter("spritesheet"),
   },
 ]);
 

--- a/app/components/TopBar.vue
+++ b/app/components/TopBar.vue
@@ -343,10 +343,10 @@ function handleKeyboard(e: KeyboardEvent) {
     (e.key === "Delete" || e.key === "Backspace") &&
     !["INPUT", "TEXTAREA", "SELECT"].includes((e.target as Element)?.tagName)
   ) {
-    // Delete or Backspace removes selected node
-    if (store.selectedNodeId) {
+    // Delete or Backspace removes selected nodes
+    if (store.selectedNodeIds.length > 0) {
       e.preventDefault();
-      store.removeNode(store.selectedNodeId);
+      store.removeSelectedNodes();
     }
     // Also remove selected edge
     if (store.selectedEdgeId) {

--- a/app/components/TopBar.vue
+++ b/app/components/TopBar.vue
@@ -343,12 +343,12 @@ function handleKeyboard(e: KeyboardEvent) {
     (e.key === "Delete" || e.key === "Backspace") &&
     !["INPUT", "TEXTAREA", "SELECT"].includes((e.target as Element)?.tagName)
   ) {
-    // Delete key removes selected node
-    if (e.key === "Delete" && store.selectedNodeId) {
+    // Delete or Backspace removes selected node
+    if (store.selectedNodeId) {
       e.preventDefault();
       store.removeNode(store.selectedNodeId);
     }
-    // Both Delete and Backspace remove selected edge
+    // Also remove selected edge
     if (store.selectedEdgeId) {
       e.preventDefault();
       store.removeEdge(store.selectedEdgeId);

--- a/app/components/nodes/BaseNode.vue
+++ b/app/components/nodes/BaseNode.vue
@@ -38,7 +38,10 @@ const statusColor = computed(() => {
 
 const isSelected = computed(() => store.selectedNodeId === props.id)
 
-const isDeletable = computed(() => props.hasInput && props.hasOutput)
+const isDeletable = computed(() => {
+  const defs = getHandleDefs(props.nodeType)
+  return defs.targets.length > 0 && defs.sources.length > 0
+})
 
 function deleteNode() {
   store.removeNode(props.id)
@@ -96,16 +99,6 @@ onUnmounted(() => {
         v-if="icon"
         class="w-3.5 h-3.5 text-gray-500 flex-shrink-0"
       />
-      <button
-        v-if="isSelected && isDeletable"
-        class="nodrag w-4 h-4 flex items-center justify-center rounded hover:bg-red-500/30 text-gray-500 hover:text-red-400 transition-colors flex-shrink-0"
-        title="Delete node"
-        @click.stop="deleteNode"
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3 h-3">
-          <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
-        </svg>
-      </button>
     </div>
 
     <!-- Output preview -->
@@ -174,25 +167,6 @@ onUnmounted(() => {
       }"
     />
 
-    <!-- Handle labels (only shown when >1 handle on a side) -->
-    <template v-if="targetHandles.length > 1">
-      <template v-for="(handle, idx) in targetHandles" :key="'label-t-' + handle.id">
-        <span
-          v-if="handle.label"
-          class="absolute text-[8px] text-gray-500 pointer-events-none"
-          :style="{ left: '14px', top: handlePosition(idx, targetHandles.length), transform: 'translateY(-50%)' }"
-        >{{ handle.label }}</span>
-      </template>
-    </template>
-    <template v-if="sourceHandles.length > 1">
-      <template v-for="(handle, idx) in sourceHandles" :key="'label-s-' + handle.id">
-        <span
-          v-if="handle.label"
-          class="absolute text-[8px] text-gray-500 pointer-events-none"
-          :style="{ right: '14px', top: handlePosition(idx, sourceHandles.length), transform: 'translateY(-50%)', textAlign: 'right' }"
-        >{{ handle.label }}</span>
-      </template>
-    </template>
   </div>
 </template>
 

--- a/app/components/nodes/BaseNode.vue
+++ b/app/components/nodes/BaseNode.vue
@@ -36,7 +36,7 @@ const statusColor = computed(() => {
   }
 })
 
-const isSelected = computed(() => store.selectedNodeId === props.id)
+const isSelected = computed(() => store.selectedNodeIds.includes(props.id))
 
 const isDeletable = computed(() => {
   const defs = getHandleDefs(props.nodeType)

--- a/app/components/nodes/BaseNode.vue
+++ b/app/components/nodes/BaseNode.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { Handle, Position } from '@vue-flow/core'
 import { usePipelineStore } from '~/stores/pipeline'
+import { getHandleDefs } from 'pipemagic'
+import type { NodeType } from '~~/shared/types/pipeline'
 
 const props = defineProps<{
   id: string
   label: string
-  hasInput?: boolean
-  hasOutput?: boolean
+  nodeType: NodeType
   hidePreview?: boolean
   color?: string
   icon?: Component
@@ -14,6 +15,15 @@ const props = defineProps<{
 
 const store = usePipelineStore()
 const state = computed(() => store.getNodeState(props.id))
+
+const handleDefs = computed(() => getHandleDefs(props.nodeType))
+const targetHandles = computed(() => handleDefs.value.targets)
+const sourceHandles = computed(() => handleDefs.value.sources)
+
+function handlePosition(index: number, total: number): string {
+  if (total === 1) return '50%'
+  return `${((index + 1) / (total + 1)) * 100}%`
+}
 
 const statusColor = computed(() => {
   switch (state.value.status) {
@@ -43,12 +53,12 @@ const borderColor = computed(() => {
 // Output preview thumbnail
 const previewUrl = ref<string | null>(null)
 
-watch(() => state.value.output, async (output) => {
+watch(() => state.value.output?.asset, async (asset) => {
   if (previewUrl.value) URL.revokeObjectURL(previewUrl.value)
-  if (output?.bitmap) {
-    const canvas = new OffscreenCanvas(output.bitmap.width, output.bitmap.height)
+  if (asset?.bitmap) {
+    const canvas = new OffscreenCanvas(asset.bitmap.width, asset.bitmap.height)
     const ctx = canvas.getContext('2d')!
-    ctx.drawImage(output.bitmap, 0, 0)
+    ctx.drawImage(asset.bitmap, 0, 0)
     const blob = await canvas.convertToBlob({ type: 'image/png' })
     previewUrl.value = URL.createObjectURL(blob)
   } else {
@@ -130,19 +140,59 @@ onUnmounted(() => {
       />
     </div>
 
-    <!-- Handles -->
+    <!-- Target handles (left side) -->
     <Handle
-      v-if="hasInput"
-      id="input"
+      v-for="(handle, idx) in targetHandles"
+      :key="handle.id"
+      :id="handle.id"
       type="target"
       :position="Position.Left"
+      :style="{
+        top: handlePosition(idx, targetHandles.length),
+        borderRadius: handle.dataType === 'data' ? '2px' : '50%',
+        background: handle.dataType === 'data' ? '#f59e0b' : undefined,
+        transform: handle.dataType === 'data' ? 'translate(-50%, -50%) rotate(45deg)' : undefined,
+        width: handle.dataType === 'data' ? '8px' : undefined,
+        height: handle.dataType === 'data' ? '8px' : undefined,
+      }"
     />
+
+    <!-- Source handles (right side) -->
     <Handle
-      v-if="hasOutput"
-      id="output"
+      v-for="(handle, idx) in sourceHandles"
+      :key="handle.id"
+      :id="handle.id"
       type="source"
       :position="Position.Right"
+      :style="{
+        top: handlePosition(idx, sourceHandles.length),
+        borderRadius: handle.dataType === 'data' ? '2px' : '50%',
+        background: handle.dataType === 'data' ? '#f59e0b' : undefined,
+        transform: handle.dataType === 'data' ? 'translate(50%, -50%) rotate(45deg)' : undefined,
+        width: handle.dataType === 'data' ? '8px' : undefined,
+        height: handle.dataType === 'data' ? '8px' : undefined,
+      }"
     />
+
+    <!-- Handle labels (only shown when >1 handle on a side) -->
+    <template v-if="targetHandles.length > 1">
+      <template v-for="(handle, idx) in targetHandles" :key="'label-t-' + handle.id">
+        <span
+          v-if="handle.label"
+          class="absolute text-[8px] text-gray-500 pointer-events-none"
+          :style="{ left: '14px', top: handlePosition(idx, targetHandles.length), transform: 'translateY(-50%)' }"
+        >{{ handle.label }}</span>
+      </template>
+    </template>
+    <template v-if="sourceHandles.length > 1">
+      <template v-for="(handle, idx) in sourceHandles" :key="'label-s-' + handle.id">
+        <span
+          v-if="handle.label"
+          class="absolute text-[8px] text-gray-500 pointer-events-none"
+          :style="{ right: '14px', top: handlePosition(idx, sourceHandles.length), transform: 'translateY(-50%)', textAlign: 'right' }"
+        >{{ handle.label }}</span>
+      </template>
+    </template>
   </div>
 </template>
 

--- a/app/components/nodes/DepthNode.vue
+++ b/app/components/nodes/DepthNode.vue
@@ -14,7 +14,7 @@ const modelLabel = computed(() => {
 </script>
 
 <template>
-  <BaseNode :id="id" :label="label || 'Estimate Depth'" :has-input="true" :has-output="true" :icon="EyeIcon">
+  <BaseNode :id="id" :label="label || 'Estimate Depth'" node-type="depth" :icon="EyeIcon">
     <div class="text-xs text-gray-400 space-y-1">
       <div class="flex justify-between">
         <span>Model</span>

--- a/app/components/nodes/FaceParseNode.vue
+++ b/app/components/nodes/FaceParseNode.vue
@@ -10,7 +10,7 @@ const state = computed(() => store.getNodeState(props.id))
 </script>
 
 <template>
-  <BaseNode :id="id" :label="label || 'Face Parse'" :has-input="true" :has-output="true" :icon="UserIcon">
+  <BaseNode :id="id" :label="label || 'Face Parse'" node-type="face-parse" :icon="UserIcon">
     <div class="text-xs text-gray-400 space-y-1">
       <div class="flex justify-between">
         <span>Device</span>

--- a/app/components/nodes/InputNode.vue
+++ b/app/components/nodes/InputNode.vue
@@ -64,7 +64,7 @@ function openFilePicker() {
   <BaseNode
     :id="id"
     :label="label || 'Input'"
-    :has-output="true"
+    node-type="input"
     :icon="PhotoIcon"
   >
     <div

--- a/app/components/nodes/NormalizeNode.vue
+++ b/app/components/nodes/NormalizeNode.vue
@@ -10,7 +10,7 @@ const state = computed(() => store.getNodeState(props.id))
 </script>
 
 <template>
-  <BaseNode :id="id" :label="label || 'Normalize'" :has-input="true" :has-output="true" :icon="ArrowsPointingInIcon">
+  <BaseNode :id="id" :label="label || 'Normalize'" node-type="normalize" :icon="ArrowsPointingInIcon">
     <div class="text-xs text-gray-400 space-y-1">
       <div class="flex justify-between">
         <span>Size</span>

--- a/app/components/nodes/OutlineNode.vue
+++ b/app/components/nodes/OutlineNode.vue
@@ -10,7 +10,7 @@ const state = computed(() => store.getNodeState(props.id))
 </script>
 
 <template>
-  <BaseNode :id="id" :label="label || 'Outline'" :has-input="true" :has-output="true" :icon="PaintBrushIcon">
+  <BaseNode :id="id" :label="label || 'Outline'" node-type="outline" :icon="PaintBrushIcon">
     <div class="text-xs text-gray-400 space-y-1">
       <div class="flex justify-between">
         <span>Thickness</span>

--- a/app/components/nodes/OutputNode.vue
+++ b/app/components/nodes/OutputNode.vue
@@ -11,11 +11,11 @@ const store = usePipelineStore()
 const state = computed(() => store.getNodeState(props.id))
 
 async function downloadOutput() {
-  const output = state.value.output
-  if (!output) return
+  const asset = state.value.output?.asset
+  if (!asset) return
   const format = (props.data.params.format as string) || 'png'
   const quality = (props.data.params.quality as number) || 0.92
-  const blob = await bitmapToBlob(output.bitmap, format as 'png' | 'jpeg' | 'webp', quality)
+  const blob = await bitmapToBlob(asset.bitmap, format as 'png' | 'jpeg' | 'webp', quality)
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url
@@ -26,13 +26,13 @@ async function downloadOutput() {
 </script>
 
 <template>
-  <BaseNode :id="id" :label="label || 'Output'" :has-input="true" :icon="ArrowDownTrayIcon">
+  <BaseNode :id="id" :label="label || 'Output'" node-type="output" :icon="ArrowDownTrayIcon">
     <div class="flex items-center justify-between">
       <span class="text-gray-500 text-xs">
-        {{ state.output ? `${state.output.width} × ${state.output.height}` : 'No output yet' }}
+        {{ state.output?.asset ? `${state.output.asset.width} × ${state.output.asset.height}` : 'No output yet' }}
       </span>
       <button
-        v-if="state.output"
+        v-if="state.output?.asset"
         class="text-[10px] px-2 py-1 rounded bg-gray-600 hover:bg-gray-500 text-white"
         @click.stop="downloadOutput"
       >

--- a/app/components/nodes/RemoveBgNode.vue
+++ b/app/components/nodes/RemoveBgNode.vue
@@ -10,7 +10,7 @@ const state = computed(() => store.getNodeState(props.id))
 </script>
 
 <template>
-  <BaseNode :id="id" :label="label || 'Remove BG'" :has-input="true" :has-output="true" :icon="ScissorsIcon">
+  <BaseNode :id="id" :label="label || 'Remove BG'" node-type="remove-bg" :icon="ScissorsIcon">
     <div class="text-xs text-gray-400 space-y-1">
       <div class="flex justify-between">
         <span>Model</span>

--- a/app/components/nodes/SpritesheetNode.vue
+++ b/app/components/nodes/SpritesheetNode.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { Squares2X2Icon } from '@heroicons/vue/20/solid'
+import BaseNode from '~/components/nodes/BaseNode.vue'
+import { usePipelineStore } from '~/stores/pipeline'
+
+const props = defineProps<{ id: string; label?: string; data: { params: Record<string, unknown> } }>()
+
+const store = usePipelineStore()
+const state = computed(() => store.getNodeState(props.id))
+
+const columnsLabel = computed(() => {
+  const v = props.data.params.columns
+  return v === 'auto' ? 'Auto' : `${v}`
+})
+
+const rowsLabel = computed(() => {
+  const v = props.data.params.rows
+  return v === 'auto' ? 'Auto' : `${v}`
+})
+</script>
+
+<template>
+  <BaseNode :id="id" :label="label || 'Spritesheet'" node-type="spritesheet" :icon="Squares2X2Icon">
+    <div class="text-xs text-gray-400 space-y-1">
+      <div class="flex justify-between">
+        <span>Columns</span>
+        <span class="text-gray-500">{{ columnsLabel }}</span>
+      </div>
+      <div class="flex justify-between">
+        <span>Rows</span>
+        <span class="text-gray-500">{{ rowsLabel }}</span>
+      </div>
+      <div class="flex justify-between">
+        <span>Gap</span>
+        <span class="text-gray-500">{{ data.params.gap }}px</span>
+      </div>
+      <div v-if="state.status === 'error'" class="text-red-400 text-[10px] mt-1">
+        {{ state.error }}
+      </div>
+    </div>
+  </BaseNode>
+</template>

--- a/app/components/nodes/UpscaleNode.vue
+++ b/app/components/nodes/UpscaleNode.vue
@@ -10,7 +10,7 @@ const state = computed(() => store.getNodeState(props.id))
 </script>
 
 <template>
-  <BaseNode :id="id" :label="label || 'Upscale'" :has-input="true" :has-output="true" :icon="ArrowsPointingOutIcon">
+  <BaseNode :id="id" :label="label || 'Upscale'" node-type="upscale" :icon="ArrowsPointingOutIcon">
     <div class="text-xs text-gray-400 space-y-1">
       <div class="flex justify-between">
         <span>Scale</span>

--- a/app/composables/useFileIo.ts
+++ b/app/composables/useFileIo.ts
@@ -101,7 +101,7 @@ export function useFileIo() {
 
     try {
       const def = JSON.parse(json) as PipelineDefinition
-      if (def.version !== 1 || !Array.isArray(def.nodes) || !Array.isArray(def.edges)) {
+      if ((def.version !== 1 && def.version !== 2) || !Array.isArray(def.nodes) || !Array.isArray(def.edges)) {
         throw new Error('Invalid pipeline file format')
       }
       store.loadPipeline(def)
@@ -118,13 +118,13 @@ export function useFileIo() {
     const inputId = nanoid(8)
     const outputId = nanoid(8)
     store.loadPipeline({
-      version: 1,
+      version: 2,
       nodes: [
         { id: inputId, type: 'input', position: { x: 100, y: 200 }, params: { maxSize: 2048, fit: 'contain' }, label: 'Image Input' },
         { id: outputId, type: 'output', position: { x: 500, y: 200 }, params: { format: 'png', quality: 0.92 }, label: 'Output' },
       ],
       edges: [
-        { id: nanoid(8), source: inputId, sourceHandle: 'output', target: outputId, targetHandle: 'input' },
+        { id: nanoid(8), source: inputId, sourceHandle: 'asset', target: outputId, targetHandle: 'asset' },
       ],
     })
     store.fileHandle = null

--- a/app/composables/usePipelineRunner.ts
+++ b/app/composables/usePipelineRunner.ts
@@ -4,7 +4,8 @@ import {
   getGpuDevice,
   createFrame,
   topoSort,
-  getUpstreamNodes,
+  getUpstreamEdges,
+  getHandleDefs,
   validatePipeline,
   computeCacheKey,
   resizeBitmap,
@@ -14,17 +15,27 @@ import {
   executeOutline,
   executeDepth,
   executeFaceParse,
+  executeSpritesheet,
 } from 'pipemagic'
 import type {
   NodeType,
   NodeDef,
   EdgeDef,
   ImageFrame,
+  NodeOutput,
   ExecutionContext,
+  LegacyNodeExecutor,
   NodeExecutor,
 } from 'pipemagic'
 
-const executors: Record<string, NodeExecutor> = {
+function wrapExecutor(fn: LegacyNodeExecutor): NodeExecutor {
+  return async (ctx, inputs, params) => {
+    const flat = Object.values(inputs).flat() as ImageFrame[]
+    return { asset: await fn(ctx, flat, params) }
+  }
+}
+
+const legacyExecutors: Record<string, LegacyNodeExecutor> = {
   'remove-bg': executeRemoveBg,
   'normalize': executeNormalize,
   'upscale': executeUpscale,
@@ -33,25 +44,32 @@ const executors: Record<string, NodeExecutor> = {
   'face-parse': executeFaceParse,
 }
 
+const executors: Record<string, NodeExecutor> = {
+  'spritesheet': executeSpritesheet,
+}
+for (const [key, fn] of Object.entries(legacyExecutors)) {
+  executors[key] = wrapExecutor(fn)
+}
+
 export function usePipelineRunner() {
   const store = usePipelineStore()
   const runError = ref<string | null>(null)
 
   async function run() {
     // Validate
-    const nodeDefs = store.nodes.map(n => ({
+    const nodeDefs = store.nodes.map((n: any) => ({
       id: n.id,
       type: n.type as NodeType,
       position: n.position,
       params: n.data?.params || {},
     })) as NodeDef[]
 
-    const edgeDefs = store.edges.map(e => ({
+    const edgeDefs = store.edges.map((e: any) => ({
       id: e.id,
       source: e.source,
-      sourceHandle: e.sourceHandle || 'output',
+      sourceHandle: e.sourceHandle || 'asset',
       target: e.target,
-      targetHandle: e.targetHandle || 'input',
+      targetHandle: e.targetHandle || 'asset',
     })) as EdgeDef[]
 
     const errors = validatePipeline(nodeDefs, edgeDefs)
@@ -63,7 +81,7 @@ export function usePipelineRunner() {
     }
 
     // Check input images
-    const inputNodes = store.nodes.filter(n => n.type === 'input')
+    const inputNodes = store.nodes.filter((n: any) => n.type === 'input')
     for (const inputNode of inputNodes) {
       if (!store.inputImages.has(inputNode.id)) {
         runError.value = 'Please add an image to the Input node before running.'
@@ -115,23 +133,39 @@ export function usePipelineRunner() {
       for (const nodeId of order) {
         if (abortController.signal.aborted) break
 
-        const node = store.nodes.find(n => n.id === nodeId)
+        const node = store.nodes.find((n: any) => n.id === nodeId)
         if (!node) continue
 
         const nodeType = node.type as NodeType
         const params = node.data?.params || {}
         console.log(`[pipeline] executing node ${nodeId} (${nodeType})`)
 
-        // Gather inputs from upstream nodes
-        const upstreamIds = getUpstreamNodes(nodeId, edgeDefs)
-        const inputs: ImageFrame[] = []
-        const inputRevisions: number[] = []
+        // Handle-aware input gathering
+        const upstreamEdges = getUpstreamEdges(nodeId, edgeDefs)
+        const handleDefs = getHandleDefs(nodeType)
+        const inputs: Record<string, ImageFrame | ImageFrame[]> = {}
+        const inputRevisions: Record<string, number[]> = {}
 
-        for (const upId of upstreamIds) {
-          const upState = store.getNodeState(upId)
-          if (upState.output) {
-            inputs.push(upState.output)
-            inputRevisions.push(upState.output.revision)
+        for (const edge of upstreamEdges) {
+          const upState = store.getNodeState(edge.source)
+          if (!upState.output) continue
+
+          const sourceOutput = upState.output[edge.sourceHandle] as ImageFrame | undefined
+          if (!sourceOutput) continue
+
+          const targetHandle = edge.targetHandle
+          const handleDef = handleDefs.targets.find(h => h.id === targetHandle)
+
+          if (handleDef?.multi) {
+            if (!inputs[targetHandle]) {
+              inputs[targetHandle] = []
+              inputRevisions[targetHandle] = []
+            }
+            ;(inputs[targetHandle] as ImageFrame[]).push(sourceOutput)
+            ;(inputRevisions[targetHandle] as number[]).push(sourceOutput.revision)
+          } else {
+            inputs[targetHandle] = sourceOutput
+            inputRevisions[targetHandle] = [sourceOutput.revision]
           }
         }
 
@@ -147,7 +181,7 @@ export function usePipelineRunner() {
         store.updateNodeState(nodeId, { status: 'running', progress: 0 })
 
         try {
-          let output: ImageFrame
+          let output: NodeOutput
 
           if (nodeType === 'input') {
             // Input node: just pass through the stored image
@@ -156,16 +190,19 @@ export function usePipelineRunner() {
             const maxSize = (params.maxSize as number) || 2048
             const fit = (params.fit as 'contain' | 'cover' | 'fill') || 'contain'
             const resized = await resizeBitmap(frame.bitmap, maxSize, fit)
-            output = createFrame(resized)
+            output = { asset: createFrame(resized) }
           } else if (nodeType === 'output') {
-            // Output node: pass through the first input
-            if (inputs.length === 0) throw new Error('No input to output node')
-            output = inputs[0]
+            // Output node: pass through inputs
+            const assetInput = inputs.asset as ImageFrame | undefined
+            if (!assetInput) throw new Error('No input to output node')
+            output = { asset: assetInput }
+            if (inputs.data) output.data = inputs.data
           } else {
             // Processing node
             const executor = executors[nodeType]
             if (!executor) throw new Error(`No executor for node type: ${nodeType}`)
-            if (inputs.length === 0) throw new Error('No input image')
+            const hasInputs = Object.keys(inputs).length > 0
+            if (!hasInputs) throw new Error('No input image')
             // Create per-node context with correct nodeId in progress callback
             const nodeCtx: ExecutionContext = {
               ...ctx,

--- a/app/stores/pipeline.ts
+++ b/app/stores/pipeline.ts
@@ -17,8 +17,15 @@ export const usePipelineStore = defineStore('pipeline', () => {
   const edges = ref<Edge[]>([])
 
   // Selection
-  const selectedNodeId = ref<string | null>(null)
+  const selectedNodeIds = ref<string[]>([])
   const selectedEdgeId = ref<string | null>(null)
+
+  // Backward-compat: last selected node (used by inspector)
+  const selectedNodeId = computed(() =>
+    selectedNodeIds.value.length > 0
+      ? selectedNodeIds.value[selectedNodeIds.value.length - 1]
+      : null,
+  )
 
   // Execution state
   const isRunning = ref(false)
@@ -57,18 +64,17 @@ export const usePipelineStore = defineStore('pipeline', () => {
   })
 
   // Actions
-  function selectNode(nodeId: string | null) {
-    selectedNodeId.value = nodeId
-    if (nodeId) selectedEdgeId.value = null
-  }
-
   function selectEdge(edgeId: string | null) {
     // Sync Vue Flow's selected state on edge objects
     for (const e of edges.value) {
       e.selected = e.id === edgeId
     }
     selectedEdgeId.value = edgeId
-    if (edgeId) selectedNodeId.value = null
+    if (edgeId) {
+      // Deselect all nodes via Vue Flow's selected property
+      for (const n of nodes.value) n.selected = false
+      selectedNodeIds.value = []
+    }
   }
 
   function removeEdge(edgeId: string) {
@@ -149,16 +155,20 @@ export const usePipelineStore = defineStore('pipeline', () => {
       'spritesheet': 'Spritesheet',
     }
 
+    // Deselect all existing nodes
+    for (const n of nodes.value) n.selected = false
+
     nodes.value.push({
       id,
       type,
       position,
       label: labels[type],
       data: { params },
+      selected: true,
     } as Node)
 
     isDirty.value = true
-    selectedNodeId.value = id
+    selectedNodeIds.value = [id]
     return id
   }
 
@@ -174,10 +184,16 @@ export const usePipelineStore = defineStore('pipeline', () => {
     nodeStates.value.delete(nodeId)
     nodeStates.value = new Map(nodeStates.value)
 
-    if (selectedNodeId.value === nodeId) {
-      selectedNodeId.value = null
-    }
+    selectedNodeIds.value = selectedNodeIds.value.filter(id => id !== nodeId)
     isDirty.value = true
+  }
+
+  function removeSelectedNodes() {
+    // Copy the array since removeNode mutates selectedNodeIds
+    const ids = [...selectedNodeIds.value]
+    for (const id of ids) {
+      removeNode(id)
+    }
   }
 
   function clearExecution() {
@@ -257,7 +273,7 @@ export const usePipelineStore = defineStore('pipeline', () => {
     fileHandle.value = null
     fileName.value = null
     isDirty.value = false
-    selectedNodeId.value = null
+    selectedNodeIds.value = []
     selectedEdgeId.value = null
     pipelineLoadCount.value++
   }
@@ -323,7 +339,7 @@ export const usePipelineStore = defineStore('pipeline', () => {
     }
 
     isDirty.value = false
-    selectedNodeId.value = null
+    selectedNodeIds.value = []
     selectedEdgeId.value = null
     pipelineLoadCount.value++
   }
@@ -356,7 +372,7 @@ export const usePipelineStore = defineStore('pipeline', () => {
     // State
     nodes,
     edges,
-    selectedNodeId,
+    selectedNodeIds,
     selectedEdgeId,
     isRunning,
     hasRun,
@@ -368,12 +384,12 @@ export const usePipelineStore = defineStore('pipeline', () => {
     isDirty,
     pipelineLoadCount,
     // Computed
+    selectedNodeId,
     selectedNode,
     selectedNodeState,
     outputNode,
     outputImage,
     // Actions
-    selectNode,
     selectEdge,
     removeEdge,
     getNodeState,
@@ -382,6 +398,7 @@ export const usePipelineStore = defineStore('pipeline', () => {
     setInputImage,
     addNode,
     removeNode,
+    removeSelectedNodes,
     clearExecution,
     loadDefaultPipeline,
     serializePipeline,

--- a/app/stores/pipeline.ts
+++ b/app/stores/pipeline.ts
@@ -132,16 +132,6 @@ export const usePipelineStore = defineStore('pipeline', () => {
     isDirty.value = true
     invalidateDownstream(nodeId)
     updateNodeState(nodeId, { output: { asset: frame }, status: 'done', cacheKey: null })
-
-    // Auto-spawn a new empty input node if all input nodes now have images
-    const inputNodeIds = nodes.value.filter(n => n.type === 'input').map(n => n.id)
-    const hasEmpty = inputNodeIds.some(id => !inputImages.value.has(id))
-    if (!hasEmpty) {
-      const currentNode = nodes.value.find(n => n.id === nodeId)
-      const y = currentNode ? currentNode.position.y + 250 : 200
-      const x = currentNode ? currentNode.position.x : 60
-      addNode('input', { x, y })
-    }
   }
 
   function addNode(type: NodeType, position: { x: number; y: number }) {

--- a/app/stores/pipeline.ts
+++ b/app/stores/pipeline.ts
@@ -3,7 +3,7 @@ import { ref, computed, watch } from 'vue'
 import type { Node, Edge } from '@vue-flow/core'
 import { nanoid } from 'nanoid'
 import type { PipelineDefinition, NodeType, NodeDef, EdgeDef } from '~~/shared/types/pipeline'
-import type { NodeState } from '~~/shared/types/execution'
+import type { NodeState, NodeOutput } from '~~/shared/types/execution'
 import { createDefaultNodeState } from '~~/shared/types/execution'
 import { DEFAULT_PARAMS, type NodeParamsMap } from '~~/shared/types/node-params'
 import type { ImageFrame } from '~~/shared/types/image-frame'
@@ -53,7 +53,7 @@ export const usePipelineStore = defineStore('pipeline', () => {
   const outputImage = computed<ImageFrame | null>(() => {
     const out = outputNode.value
     if (!out) return null
-    return nodeStates.value.get(out.id)?.output || null
+    return nodeStates.value.get(out.id)?.output?.asset || null
   })
 
   // Actions
@@ -106,9 +106,9 @@ export const usePipelineStore = defineStore('pipeline', () => {
     const edgeDefs = edges.value.map(e => ({
       id: e.id,
       source: e.source,
-      sourceHandle: e.sourceHandle || 'output',
+      sourceHandle: e.sourceHandle || 'asset',
       target: e.target,
-      targetHandle: e.targetHandle || 'input',
+      targetHandle: e.targetHandle || 'asset',
     })) as EdgeDef[]
     for (const id of getDownstreamNodes(nodeId, edgeDefs)) {
       invalidateNode(id)
@@ -131,7 +131,17 @@ export const usePipelineStore = defineStore('pipeline', () => {
     inputImages.value = new Map(inputImages.value)
     isDirty.value = true
     invalidateDownstream(nodeId)
-    updateNodeState(nodeId, { output: frame, status: 'done', cacheKey: null })
+    updateNodeState(nodeId, { output: { asset: frame }, status: 'done', cacheKey: null })
+
+    // Auto-spawn a new empty input node if all input nodes now have images
+    const inputNodeIds = nodes.value.filter(n => n.type === 'input').map(n => n.id)
+    const hasEmpty = inputNodeIds.some(id => !inputImages.value.has(id))
+    if (!hasEmpty) {
+      const currentNode = nodes.value.find(n => n.id === nodeId)
+      const y = currentNode ? currentNode.position.y + 250 : 200
+      const x = currentNode ? currentNode.position.x : 60
+      addNode('input', { x, y })
+    }
   }
 
   function addNode(type: NodeType, position: { x: number; y: number }) {
@@ -146,6 +156,7 @@ export const usePipelineStore = defineStore('pipeline', () => {
       'outline': 'Outline',
       'depth': 'Estimate Depth',
       'face-parse': 'Face Parse',
+      'spritesheet': 'Spritesheet',
     }
 
     nodes.value.push({
@@ -164,8 +175,9 @@ export const usePipelineStore = defineStore('pipeline', () => {
   function removeNode(nodeId: string) {
     const node = nodes.value.find(n => n.id === nodeId)
     if (!node) return
-    // Prevent deleting input/output nodes
-    if (node.type === 'input' || node.type === 'output') return
+    // Prevent deleting the last input or last output node
+    if (node.type === 'input' && nodes.value.filter(n => n.type === 'input').length <= 1) return
+    if (node.type === 'output' && nodes.value.filter(n => n.type === 'output').length <= 1) return
 
     nodes.value = nodes.value.filter(n => n.id !== nodeId)
     edges.value = edges.value.filter(e => e.source !== nodeId && e.target !== nodeId)
@@ -185,7 +197,7 @@ export const usePipelineStore = defineStore('pipeline', () => {
     nodeStates.value = new Map(nodeStates.value)
     // Preserve input images
     for (const [id, frame] of inputImages.value) {
-      updateNodeState(id, { output: frame, status: 'done' })
+      updateNodeState(id, { output: { asset: frame }, status: 'done' })
     }
   }
 
@@ -243,11 +255,11 @@ export const usePipelineStore = defineStore('pipeline', () => {
     ] as Node[]
 
     edges.value = [
-      { id: nanoid(8), source: inputId, target: removeBgId, sourceHandle: 'output', targetHandle: 'input' },
-      { id: nanoid(8), source: removeBgId, target: normalizeId, sourceHandle: 'output', targetHandle: 'input' },
-      { id: nanoid(8), source: normalizeId, target: outlineId, sourceHandle: 'output', targetHandle: 'input' },
-      { id: nanoid(8), source: outlineId, target: upscaleId, sourceHandle: 'output', targetHandle: 'input' },
-      { id: nanoid(8), source: upscaleId, target: outputId, sourceHandle: 'output', targetHandle: 'input' },
+      { id: nanoid(8), source: inputId, target: removeBgId, sourceHandle: 'asset', targetHandle: 'asset' },
+      { id: nanoid(8), source: removeBgId, target: normalizeId, sourceHandle: 'asset', targetHandle: 'asset' },
+      { id: nanoid(8), source: normalizeId, target: outlineId, sourceHandle: 'asset', targetHandle: 'asset' },
+      { id: nanoid(8), source: outlineId, target: upscaleId, sourceHandle: 'asset', targetHandle: 'asset' },
+      { id: nanoid(8), source: upscaleId, target: outputId, sourceHandle: 'asset', targetHandle: 'asset' },
     ] as Edge[]
 
     nodeStates.value = new Map()
@@ -262,7 +274,7 @@ export const usePipelineStore = defineStore('pipeline', () => {
 
   function serializePipeline(): PipelineDefinition {
     return {
-      version: 1,
+      version: 2,
       nodes: nodes.value.map(n => ({
         id: n.id,
         type: n.type as NodeType,
@@ -273,9 +285,9 @@ export const usePipelineStore = defineStore('pipeline', () => {
       edges: edges.value.map(e => ({
         id: e.id,
         source: e.source,
-        sourceHandle: e.sourceHandle || 'output',
+        sourceHandle: e.sourceHandle || 'asset',
         target: e.target,
-        targetHandle: e.targetHandle || 'input',
+        targetHandle: e.targetHandle || 'asset',
       })),
     }
   }
@@ -292,12 +304,13 @@ export const usePipelineStore = defineStore('pipeline', () => {
       data: { params: n.params },
     })) as Node[]
 
+    // Migrate v1 handle names: "output" → "asset", "input" → "asset"
     edges.value = def.edges.map(e => ({
       id: e.id,
       source: e.source,
-      sourceHandle: e.sourceHandle,
+      sourceHandle: e.sourceHandle === 'output' ? 'asset' : e.sourceHandle,
       target: e.target,
-      targetHandle: e.targetHandle,
+      targetHandle: e.targetHandle === 'input' ? 'asset' : e.targetHandle,
     })) as Edge[]
 
     nodeStates.value = new Map()
@@ -310,7 +323,7 @@ export const usePipelineStore = defineStore('pipeline', () => {
           inputImages.value.set(node.id, previousImage)
           nodeStates.value.set(node.id, {
             ...createDefaultNodeState(),
-            output: previousImage,
+            output: { asset: previousImage },
             status: 'done',
           })
         }

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -106,6 +106,17 @@ Face segmentation into 19 classes (skin, eyes, brows, nose, mouth, lips, ears, h
 | `model`       | `'cnn-2x-s' \| 'cnn-2x-m' \| 'cnn-2x-l'` | `'cnn-2x-s'` | Model size        |
 | `contentType` | `'rl' \| 'an' \| '3d'`                   | `'rl'`       | Content type hint |
 
+### `spritesheet`
+
+Composites multiple input images into a grid spritesheet. Accepts multiple connections on its `images` input handle. Outputs the combined image plus a JSON data object with per-frame positions and UV coordinates.
+
+| Param     | Type                 | Default         | Description                        |
+| --------- | -------------------- | --------------- | ---------------------------------- |
+| `columns` | `number \| 'auto'`   | `'auto'`        | Number of columns (auto = √n)      |
+| `rows`    | `number \| 'auto'`   | `'auto'`        | Number of rows (auto = ceil(n/cols))|
+| `gap`     | `number`             | `0`             | Gap between cells in pixels        |
+| `bgColor` | `string`             | `'transparent'` | Background color (hex or `'transparent'`) |
+
 ### `output`
 
 Encodes the final image as a Blob.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -31,6 +31,40 @@ const result = await pm.run(pipeline, imageFile, {
 // result.width, result.height → dimensions
 ```
 
+### Multiple inputs
+
+Pipelines with multiple input nodes accept a record keyed by node label or ID:
+
+```ts
+const result = await pm.run(pipeline, {
+  "Image Input": file1,
+  "Background": file2,
+});
+```
+
+Values can be `Blob`, `File`, or `ImageBitmap`. A single value (not a record) is still supported for pipelines with one input.
+
+### Multiple outputs
+
+`RunResult` includes all output nodes, keyed by label:
+
+```ts
+const result = await pm.run(pipeline, imageFile);
+
+// Primary output (first output node)
+result.blob; // Blob
+result.width;
+result.height;
+
+// All outputs by label
+for (const [label, entry] of Object.entries(result.outputs)) {
+  entry.asset; // Blob
+  entry.width;
+  entry.height;
+  entry.data; // optional structured data (e.g. spritesheet frame data)
+}
+```
+
 ## Pipeline Definition
 
 Pipelines are JSON graphs of nodes and edges. Each node has a type, parameters, and connects to other nodes via edges.
@@ -119,7 +153,7 @@ Composites multiple input images into a grid spritesheet. Accepts multiple conne
 
 ### `output`
 
-Encodes the final image as a Blob.
+Encodes the final image as a Blob. Also accepts an optional `data` input handle for passing through structured data (e.g. spritesheet frame coordinates).
 
 | Param     | Type                        | Default | Description         |
 | --------- | --------------------------- | ------- | ------------------- |
@@ -159,6 +193,7 @@ import {
   executeOutline,
   executeDepth,
   executeFaceParse,
+  executeSpritesheet,
   initGpu,
   getGpuDevice,
   createFrame,
@@ -178,6 +213,20 @@ const result = await executeRemoveBg(ctx, [inputFrame], {
   threshold: 0.5,
   device: "auto",
   dtype: "fp16",
+});
+```
+
+## Custom Executors
+
+Register custom node executors to extend the pipeline with your own processing steps:
+
+```ts
+import { registerExecutor } from "pipemagic";
+
+registerExecutor("my-node", async (ctx, inputs, params) => {
+  const image = inputs.asset; // ImageFrame
+  // ... process image ...
+  return { asset: outputFrame };
 });
 ```
 

--- a/packages/runtime/src/executors/spritesheet.ts
+++ b/packages/runtime/src/executors/spritesheet.ts
@@ -1,0 +1,133 @@
+import type { ExecutionContext } from '../types/execution'
+import type { NodeOutput } from '../types/execution'
+import type { ImageFrame } from '../types/image-frame'
+
+export interface SpritesheetFrame {
+  name: string
+  x: number
+  y: number
+  w: number
+  h: number
+  u0: number
+  v0: number
+  u1: number
+  v1: number
+}
+
+export interface SpritesheetData {
+  frames: SpritesheetFrame[]
+  width: number
+  height: number
+}
+
+export async function executeSpritesheet(
+  ctx: ExecutionContext,
+  inputs: Record<string, ImageFrame | ImageFrame[]>,
+  params: Record<string, unknown>,
+): Promise<NodeOutput> {
+  const images = inputs.images
+  if (!images) throw new Error('No images connected to spritesheet node')
+
+  const frames = Array.isArray(images) ? images : [images]
+  if (frames.length === 0) throw new Error('No images connected to spritesheet node')
+
+  ctx.onProgress('', 0.1)
+
+  const columnsParam = params.columns as number | 'auto' ?? 'auto'
+  const rowsParam = params.rows as number | 'auto' ?? 'auto'
+  const gap = (params.gap as number) ?? 0
+  const bgColor = (params.bgColor as string) ?? 'transparent'
+
+  // Compute grid dimensions
+  let columns: number
+  let rows: number
+
+  if (columnsParam !== 'auto' && rowsParam !== 'auto') {
+    columns = columnsParam
+    rows = rowsParam
+  } else if (columnsParam !== 'auto') {
+    columns = columnsParam
+    rows = Math.ceil(frames.length / columns)
+  } else if (rowsParam !== 'auto') {
+    rows = rowsParam
+    columns = Math.ceil(frames.length / rows)
+  } else {
+    columns = Math.ceil(Math.sqrt(frames.length))
+    rows = Math.ceil(frames.length / columns)
+  }
+
+  // Uniform cell size: max width/height across all inputs
+  let cellW = 0
+  let cellH = 0
+  for (const frame of frames) {
+    if (frame.width > cellW) cellW = frame.width
+    if (frame.height > cellH) cellH = frame.height
+  }
+
+  // Sheet dimensions
+  const sheetW = columns * cellW + (columns - 1) * gap
+  const sheetH = rows * cellH + (rows - 1) * gap
+
+  ctx.onProgress('', 0.3)
+
+  // Draw grid
+  const canvas = new OffscreenCanvas(sheetW, sheetH)
+  const drawCtx = canvas.getContext('2d')!
+
+  if (bgColor !== 'transparent') {
+    drawCtx.fillStyle = bgColor
+    drawCtx.fillRect(0, 0, sheetW, sheetH)
+  }
+
+  const frameData: SpritesheetFrame[] = []
+
+  for (let i = 0; i < frames.length; i++) {
+    if (ctx.abortSignal.aborted) throw new DOMException('Aborted', 'AbortError')
+
+    const frame = frames[i]
+    const col = i % columns
+    const row = Math.floor(i / columns)
+
+    const cellX = col * (cellW + gap)
+    const cellY = row * (cellH + gap)
+
+    // Center image in cell
+    const offsetX = cellX + Math.floor((cellW - frame.width) / 2)
+    const offsetY = cellY + Math.floor((cellH - frame.height) / 2)
+
+    drawCtx.drawImage(frame.bitmap, offsetX, offsetY)
+
+    frameData.push({
+      name: `frame_${i}`,
+      x: offsetX,
+      y: offsetY,
+      w: frame.width,
+      h: frame.height,
+      u0: offsetX / sheetW,
+      v0: offsetY / sheetH,
+      u1: (offsetX + frame.width) / sheetW,
+      v1: (offsetY + frame.height) / sheetH,
+    })
+
+    ctx.onProgress('', 0.3 + (0.6 * (i + 1) / frames.length))
+  }
+
+  const bitmap = await createImageBitmap(canvas)
+  ctx.onProgress('', 1)
+
+  const data: SpritesheetData = {
+    frames: frameData,
+    width: sheetW,
+    height: sheetH,
+  }
+
+  return {
+    asset: {
+      bitmap,
+      width: sheetW,
+      height: sheetH,
+      revision: Date.now(),
+    },
+    data,
+  }
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -8,7 +8,7 @@ export class PipeMagic {
 
   async run(
     pipeline: PipelineDefinition,
-    inputImage: Blob | File | ImageBitmap,
+    inputImage: Blob | File | ImageBitmap | Record<string, Blob | File | ImageBitmap>,
     options: RunOptions = {},
   ): Promise<RunResult> {
     // Init GPU once
@@ -17,22 +17,30 @@ export class PipeMagic {
       this.gpuInitialized = true
     }
 
-    // Convert input to ImageBitmap if needed
-    let bitmap: ImageBitmap
-    if (inputImage instanceof ImageBitmap) {
-      bitmap = inputImage
+    // Convert input(s) to ImageBitmap
+    if (inputImage instanceof Blob || inputImage instanceof File || inputImage instanceof ImageBitmap) {
+      // Single input (backward-compat)
+      const bitmap = inputImage instanceof ImageBitmap
+        ? inputImage
+        : await createImageBitmap(inputImage)
+      return runPipeline(pipeline, bitmap, getGpuDevice(), options)
     } else {
-      bitmap = await createImageBitmap(inputImage)
+      // Multi-input: Record<string, Blob | File | ImageBitmap>
+      const bitmapMap = new Map<string, ImageBitmap>()
+      for (const [key, value] of Object.entries(inputImage)) {
+        const bitmap = value instanceof ImageBitmap
+          ? value
+          : await createImageBitmap(value)
+        bitmapMap.set(key, bitmap)
+      }
+      return runPipeline(pipeline, bitmapMap, getGpuDevice(), options)
     }
-
-    return runPipeline(pipeline, bitmap, getGpuDevice(), options)
   }
 }
 
 // Re-export everything consumers might need
-export { runPipeline } from './runner'
-export type { RunOptions, RunResult } from './runner'
-export type { NodeExecutor } from './runner'
+export { runPipeline, registerExecutor } from './runner'
+export type { RunOptions, RunResult, OutputEntry, NodeExecutor, LegacyNodeExecutor } from './runner'
 
 export { initGpu, getGpuDevice } from './utils/gpu'
 
@@ -40,6 +48,7 @@ export type {
   ImageFrame,
   NodeStatus,
   NodeState,
+  NodeOutput,
   ExecutionContext,
   NodeType,
   NodePosition,
@@ -54,15 +63,22 @@ export type {
   OutlineParams,
   DepthParams,
   FaceParseParams,
+  SpritesheetParams,
   NodeParamsMap,
+  HandleDataType,
+  HandleDef,
 } from './types'
 export { createDefaultNodeState, DEFAULT_PARAMS } from './types'
+
+export { getHandleDefs } from './registry'
+export type { NodeHandleDefs } from './registry'
 
 export {
   topoSort,
   hasCycle,
   validatePipeline,
   getUpstreamNodes,
+  getUpstreamEdges,
   getDownstreamNodes,
 } from './utils/graph'
 export type { ValidationError } from './utils/graph'
@@ -91,3 +107,5 @@ export { executeUpscale } from './executors/upscale'
 export { executeOutline } from './executors/outline'
 export { executeDepth } from './executors/depth'
 export { executeFaceParse } from './executors/face-parse'
+export { executeSpritesheet } from './executors/spritesheet'
+export type { SpritesheetData, SpritesheetFrame } from './executors/spritesheet'

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -1,0 +1,56 @@
+import type { HandleDef } from './types/handles'
+import type { NodeType } from './types/pipeline'
+
+export interface NodeHandleDefs {
+  targets: HandleDef[]
+  sources: HandleDef[]
+}
+
+const registry: Record<NodeType, NodeHandleDefs> = {
+  'input': {
+    targets: [],
+    sources: [{ id: 'asset', direction: 'source', dataType: 'image' }],
+  },
+  'remove-bg': {
+    targets: [{ id: 'asset', direction: 'target', dataType: 'image' }],
+    sources: [{ id: 'asset', direction: 'source', dataType: 'image' }],
+  },
+  'normalize': {
+    targets: [{ id: 'asset', direction: 'target', dataType: 'image' }],
+    sources: [{ id: 'asset', direction: 'source', dataType: 'image' }],
+  },
+  'outline': {
+    targets: [{ id: 'asset', direction: 'target', dataType: 'image' }],
+    sources: [{ id: 'asset', direction: 'source', dataType: 'image' }],
+  },
+  'upscale': {
+    targets: [{ id: 'asset', direction: 'target', dataType: 'image' }],
+    sources: [{ id: 'asset', direction: 'source', dataType: 'image' }],
+  },
+  'depth': {
+    targets: [{ id: 'asset', direction: 'target', dataType: 'image' }],
+    sources: [{ id: 'asset', direction: 'source', dataType: 'image' }],
+  },
+  'face-parse': {
+    targets: [{ id: 'asset', direction: 'target', dataType: 'image' }],
+    sources: [{ id: 'asset', direction: 'source', dataType: 'image' }],
+  },
+  'spritesheet': {
+    targets: [{ id: 'images', direction: 'target', dataType: 'image', multi: true, label: 'Images' }],
+    sources: [
+      { id: 'asset', direction: 'source', dataType: 'image', label: 'Sheet' },
+      { id: 'data', direction: 'source', dataType: 'data', label: 'Data' },
+    ],
+  },
+  'output': {
+    targets: [
+      { id: 'asset', direction: 'target', dataType: 'image' },
+      { id: 'data', direction: 'target', dataType: 'data', label: 'Data' },
+    ],
+    sources: [],
+  },
+}
+
+export function getHandleDefs(nodeType: NodeType): NodeHandleDefs {
+  return registry[nodeType] ?? { targets: [], sources: [] }
+}

--- a/packages/runtime/src/runner.ts
+++ b/packages/runtime/src/runner.ts
@@ -1,25 +1,43 @@
 import type { NodeType, NodeDef, EdgeDef, PipelineDefinition } from './types/pipeline'
 import type { ImageFrame } from './types/image-frame'
-import type { ExecutionContext, NodeStatus, NodeState } from './types/execution'
+import type { ExecutionContext, NodeStatus, NodeState, NodeOutput } from './types/execution'
 import { createDefaultNodeState } from './types/execution'
-import { topoSort, getUpstreamNodes, validatePipeline } from './utils/graph'
+import { topoSort, getUpstreamEdges, validatePipeline } from './utils/graph'
 import { computeCacheKey } from './utils/hash'
 import { resizeBitmap } from './utils/image'
 import { createFrame } from './utils/gpu'
+import { getHandleDefs } from './registry'
 import { executeRemoveBg } from './executors/remove-bg'
 import { executeUpscale } from './executors/upscale'
 import { executeNormalize } from './executors/normalize'
 import { executeOutline } from './executors/outline'
 import { executeDepth } from './executors/depth'
 import { executeFaceParse } from './executors/face-parse'
+import { executeSpritesheet } from './executors/spritesheet'
 
-export type NodeExecutor = (
+/** Legacy executor signature (single ImageFrame[] in, single ImageFrame out). */
+export type LegacyNodeExecutor = (
   ctx: ExecutionContext,
   inputs: ImageFrame[],
   params: Record<string, unknown>,
 ) => Promise<ImageFrame>
 
-const executors: Record<string, NodeExecutor> = {
+/** New executor signature: named inputs, NodeOutput out. */
+export type NodeExecutor = (
+  ctx: ExecutionContext,
+  inputs: Record<string, ImageFrame | ImageFrame[]>,
+  params: Record<string, unknown>,
+) => Promise<NodeOutput>
+
+/** Wrap a legacy executor to the new signature. */
+function wrapExecutor(fn: LegacyNodeExecutor): NodeExecutor {
+  return async (ctx, inputs, params) => {
+    const flat = Object.values(inputs).flat() as ImageFrame[]
+    return { asset: await fn(ctx, flat, params) }
+  }
+}
+
+const legacyExecutors: Record<string, LegacyNodeExecutor> = {
   'remove-bg': executeRemoveBg,
   'normalize': executeNormalize,
   'upscale': executeUpscale,
@@ -27,6 +45,21 @@ const executors: Record<string, NodeExecutor> = {
   'depth': executeDepth,
   'face-parse': executeFaceParse,
 }
+
+const executors: Record<string, NodeExecutor> = {
+  'spritesheet': executeSpritesheet,
+}
+for (const [key, fn] of Object.entries(legacyExecutors)) {
+  executors[key] = wrapExecutor(fn)
+}
+
+/** Register a native v2 executor (e.g. spritesheet). */
+export function registerExecutor(nodeType: string, executor: NodeExecutor) {
+  executors[nodeType] = executor
+}
+
+// Keep the old type name as an alias for backwards compat
+export { LegacyNodeExecutor as NodeExecutorLegacy }
 
 export interface RunOptions {
   signal?: AbortSignal
@@ -36,20 +69,38 @@ export interface RunOptions {
   onNodeDownloadProgress?: (nodeId: string, progress: number | null) => void
 }
 
+export interface OutputEntry {
+  asset: Blob
+  width: number
+  height: number
+  data?: unknown
+}
+
 export interface RunResult {
   blob: Blob
   width: number
   height: number
-  nodeOutputs: Map<string, ImageFrame>
+  outputs: Record<string, OutputEntry>
+  nodeOutputs: Map<string, NodeOutput>
+}
+
+/** Migrate v1 handle names to v2. */
+function migrateEdges(edges: EdgeDef[]): EdgeDef[] {
+  return edges.map(e => ({
+    ...e,
+    sourceHandle: e.sourceHandle === 'output' ? 'asset' : e.sourceHandle,
+    targetHandle: e.targetHandle === 'input' ? 'asset' : e.targetHandle,
+  }))
 }
 
 export async function runPipeline(
   pipeline: PipelineDefinition,
-  inputImage: ImageBitmap,
+  inputImage: ImageBitmap | Map<string, ImageBitmap>,
   gpuDevice: GPUDevice | null,
   options: RunOptions = {},
 ): Promise<RunResult> {
-  const { nodes, edges } = pipeline
+  const { nodes } = pipeline
+  const edges = migrateEdges(pipeline.edges)
   const { signal, onNodeProgress, onNodeStatus, onNodeStatusMessage, onNodeDownloadProgress } = options
 
   // Validate
@@ -58,10 +109,15 @@ export async function runPipeline(
     throw new Error(`Pipeline validation failed: ${errors.map(e => e.message).join('; ')}`)
   }
 
+  // Normalize input to Map
+  const inputMap: Map<string, ImageBitmap> = inputImage instanceof Map
+    ? inputImage
+    : new Map([['__default__', inputImage]])
+
   // Set up abort
   const abortSignal = signal ?? new AbortController().signal
 
-  // Local node state (replaces Pinia store)
+  // Local node state
   const nodeStates = new Map<string, NodeState>()
   for (const node of nodes) {
     nodeStates.set(node.id, createDefaultNodeState())
@@ -97,11 +153,8 @@ export async function runPipeline(
   // Topo sort
   const order = topoSort(nodes, edges)
 
-  // Store the input image as a frame for input nodes
-  const inputFrame = createFrame(inputImage)
-
-  // Track last output for returning
-  let lastOutputFrame: ImageFrame | null = null
+  // Track output nodes for final result
+  const outputNodeIds: string[] = []
 
   // Execute in order
   for (const nodeId of order) {
@@ -113,16 +166,33 @@ export async function runPipeline(
     const nodeType = node.type as NodeType
     const params = node.params || {}
 
-    // Gather inputs from upstream nodes
-    const upstreamIds = getUpstreamNodes(nodeId, edges)
-    const inputs: ImageFrame[] = []
-    const inputRevisions: number[] = []
+    // Handle-aware input gathering
+    const upstreamEdges = getUpstreamEdges(nodeId, edges)
+    const handleDefs = getHandleDefs(nodeType)
+    const inputs: Record<string, ImageFrame | ImageFrame[]> = {}
+    const inputRevisions: Record<string, number[]> = {}
 
-    for (const upId of upstreamIds) {
-      const upState = nodeStates.get(upId)
-      if (upState?.output) {
-        inputs.push(upState.output)
-        inputRevisions.push(upState.output.revision)
+    for (const edge of upstreamEdges) {
+      const upState = nodeStates.get(edge.source)
+      if (!upState?.output) continue
+
+      const sourceOutput = upState.output[edge.sourceHandle] as ImageFrame | undefined
+      if (!sourceOutput) continue
+
+      const targetHandle = edge.targetHandle
+      const handleDef = handleDefs.targets.find(h => h.id === targetHandle)
+
+      if (handleDef?.multi) {
+        // Accumulate into array
+        if (!inputs[targetHandle]) {
+          inputs[targetHandle] = []
+          inputRevisions[targetHandle] = []
+        }
+        ;(inputs[targetHandle] as ImageFrame[]).push(sourceOutput)
+        ;(inputRevisions[targetHandle] as number[]).push(sourceOutput.revision)
+      } else {
+        inputs[targetHandle] = sourceOutput
+        inputRevisions[targetHandle] = [sourceOutput.revision]
       }
     }
 
@@ -132,7 +202,7 @@ export async function runPipeline(
     if (existingState.cacheKey === cacheKey && existingState.output) {
       updateState(nodeId, { status: 'cached' })
       onNodeStatus?.(nodeId, 'cached')
-      if (nodeType === 'output') lastOutputFrame = existingState.output
+      if (nodeType === 'output') outputNodeIds.push(nodeId)
       continue
     }
 
@@ -141,21 +211,34 @@ export async function runPipeline(
     onNodeStatus?.(nodeId, 'running')
 
     try {
-      let output: ImageFrame
+      let output: NodeOutput
 
       if (nodeType === 'input') {
+        // Look up input image by label, then by id, then default
+        const label = node.label || node.id
+        let bitmap = inputMap.get(label) ?? inputMap.get(node.id) ?? inputMap.get('__default__')
+        if (!bitmap) throw new Error(`No input image for "${label}"`)
+
         const maxSize = (params.maxSize as number) || 2048
         const fit = (params.fit as 'contain' | 'cover' | 'fill') || 'contain'
-        const resized = await resizeBitmap(inputFrame.bitmap, maxSize, fit)
-        output = createFrame(resized)
+        const resized = await resizeBitmap(bitmap, maxSize, fit)
+        output = { asset: createFrame(resized) }
       } else if (nodeType === 'output') {
-        if (inputs.length === 0) throw new Error('No input to output node')
-        output = inputs[0]
+        const assetInput = inputs.asset as ImageFrame | undefined
+        if (!assetInput) throw new Error('No input to output node')
+        output = { asset: assetInput }
+        // Pass through data handle if connected
+        const dataInput = inputs.data
+        if (dataInput) output.data = dataInput
+        outputNodeIds.push(nodeId)
       } else {
         const executor = executors[nodeType]
         if (!executor) throw new Error(`No executor for node type: ${nodeType}`)
-        if (inputs.length === 0) throw new Error('No input image')
-        // Create per-node context with correct nodeId in progress callback
+
+        const hasInputs = Object.keys(inputs).length > 0
+        if (!hasInputs) throw new Error('No input image')
+
+        // Create per-node context
         const nodeCtx: ExecutionContext = {
           ...ctx,
           onProgress: (_id, progress) => ctx.onProgress(nodeId, progress),
@@ -176,8 +259,6 @@ export async function runPipeline(
         error: null,
       })
       onNodeStatus?.(nodeId, 'done')
-
-      if (nodeType === 'output') lastOutputFrame = output
     } catch (e: any) {
       if (e.name === 'AbortError' || abortSignal.aborted) {
         throw new DOMException('Aborted', 'AbortError')
@@ -190,28 +271,53 @@ export async function runPipeline(
     }
   }
 
-  if (!lastOutputFrame) {
+  // Build results from all output nodes
+  const { bitmapToBlob } = await import('./utils/image')
+  const outputs: Record<string, OutputEntry> = {}
+
+  for (const outId of outputNodeIds) {
+    const outNode = nodes.find(n => n.id === outId)!
+    const outState = nodeStates.get(outId)
+    if (!outState?.output) continue
+
+    const format = (outNode.params?.format as 'png' | 'jpeg' | 'webp') || 'png'
+    const quality = (outNode.params?.quality as number) ?? 0.92
+    const assetFrame = outState.output.asset
+    const blob = await bitmapToBlob(assetFrame.bitmap, format, quality)
+
+    const label = outNode.label || outNode.id
+    outputs[label] = {
+      asset: blob,
+      width: assetFrame.width,
+      height: assetFrame.height,
+      data: outState.output.data,
+    }
+  }
+
+  // Primary output: first output node
+  const primaryOutputId = outputNodeIds[0]
+  const primaryState = primaryOutputId ? nodeStates.get(primaryOutputId) : null
+  if (!primaryState?.output) {
     throw new Error('Pipeline produced no output')
   }
 
-  // Find the output node's format params for blob conversion
-  const outputNode = nodes.find(n => n.type === 'output')
-  const format = (outputNode?.params?.format as 'png' | 'jpeg' | 'webp') || 'png'
-  const quality = (outputNode?.params?.quality as number) ?? 0.92
-
-  const { bitmapToBlob } = await import('./utils/image')
-  const blob = await bitmapToBlob(lastOutputFrame.bitmap, format, quality)
+  const primaryNode = nodes.find(n => n.id === primaryOutputId)!
+  const primaryFormat = (primaryNode.params?.format as 'png' | 'jpeg' | 'webp') || 'png'
+  const primaryQuality = (primaryNode.params?.quality as number) ?? 0.92
+  const primaryFrame = primaryState.output.asset
+  const primaryBlob = await bitmapToBlob(primaryFrame.bitmap, primaryFormat, primaryQuality)
 
   // Collect all node outputs
-  const nodeOutputs = new Map<string, ImageFrame>()
+  const nodeOutputs = new Map<string, NodeOutput>()
   for (const [id, state] of nodeStates) {
     if (state.output) nodeOutputs.set(id, state.output)
   }
 
   return {
-    blob,
-    width: lastOutputFrame.width,
-    height: lastOutputFrame.height,
+    blob: primaryBlob,
+    width: primaryFrame.width,
+    height: primaryFrame.height,
+    outputs,
     nodeOutputs,
   }
 }

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -2,6 +2,7 @@ export type { ImageFrame } from './types/image-frame'
 export type {
   NodeStatus,
   NodeState,
+  NodeOutput,
   ExecutionContext,
 } from './types/execution'
 export { createDefaultNodeState } from './types/execution'
@@ -21,6 +22,8 @@ export type {
   OutlineParams,
   DepthParams,
   FaceParseParams,
+  SpritesheetParams,
   NodeParamsMap,
 } from './types/node-params'
 export { DEFAULT_PARAMS } from './types/node-params'
+export type { HandleDataType, HandleDef } from './types/handles'

--- a/packages/runtime/src/types/execution.ts
+++ b/packages/runtime/src/types/execution.ts
@@ -2,13 +2,18 @@ import type { ImageFrame } from './image-frame'
 
 export type NodeStatus = 'idle' | 'pending' | 'running' | 'done' | 'error' | 'cached'
 
+export interface NodeOutput {
+  asset: ImageFrame
+  [key: string]: ImageFrame | unknown
+}
+
 export interface NodeState {
   status: NodeStatus
   progress: number
   statusMessage: string | null
   downloadProgress: number | null
   error: string | null
-  output: ImageFrame | null
+  output: NodeOutput | null
   cacheKey: string | null
   deviceUsed?: 'webgpu' | 'wasm' | null
 }

--- a/packages/runtime/src/types/handles.ts
+++ b/packages/runtime/src/types/handles.ts
@@ -1,0 +1,9 @@
+export type HandleDataType = 'image' | 'data'
+
+export interface HandleDef {
+  id: string
+  direction: 'source' | 'target'
+  dataType: HandleDataType
+  multi?: boolean
+  label?: string
+}

--- a/packages/runtime/src/types/node-params.ts
+++ b/packages/runtime/src/types/node-params.ts
@@ -41,6 +41,13 @@ export interface FaceParseParams {
   device: 'webgpu' | 'wasm' | 'auto'
 }
 
+export interface SpritesheetParams {
+  columns: number | 'auto'
+  rows: number | 'auto'
+  gap: number
+  bgColor: string
+}
+
 export type NodeParamsMap = {
   'input': InputNodeParams
   'output': OutputNodeParams
@@ -50,6 +57,7 @@ export type NodeParamsMap = {
   'outline': OutlineParams
   'depth': DepthParams
   'face-parse': FaceParseParams
+  'spritesheet': SpritesheetParams
 }
 
 export const DEFAULT_PARAMS: NodeParamsMap = {
@@ -61,4 +69,5 @@ export const DEFAULT_PARAMS: NodeParamsMap = {
   'outline': { thickness: 4, color: '#ffffff', opacity: 1, quality: 'medium', position: 'outside', threshold: 0 },
   'depth': { model: 'fast', device: 'auto' },
   'face-parse': { device: 'auto' },
+  'spritesheet': { columns: 'auto', rows: 'auto', gap: 0, bgColor: 'transparent' },
 }

--- a/packages/runtime/src/types/pipeline.ts
+++ b/packages/runtime/src/types/pipeline.ts
@@ -1,4 +1,4 @@
-export type NodeType = 'input' | 'output' | 'remove-bg' | 'normalize' | 'upscale' | 'outline' | 'depth' | 'face-parse'
+export type NodeType = 'input' | 'output' | 'remove-bg' | 'normalize' | 'upscale' | 'outline' | 'depth' | 'face-parse' | 'spritesheet'
 
 export interface NodePosition {
   x: number
@@ -22,7 +22,7 @@ export interface EdgeDef {
 }
 
 export interface PipelineDefinition {
-  version: 1
+  version: 1 | 2
   nodes: NodeDef[]
   edges: EdgeDef[]
 }

--- a/packages/runtime/src/utils/graph.ts
+++ b/packages/runtime/src/utils/graph.ts
@@ -1,4 +1,5 @@
-import type { NodeDef, EdgeDef } from '../types/pipeline'
+import type { NodeDef, EdgeDef, NodeType } from '../types/pipeline'
+import { getHandleDefs } from '../registry'
 
 export interface ValidationError {
   nodeId?: string
@@ -76,6 +77,7 @@ export function validatePipeline(nodes: NodeDef[], edges: EdgeDef[]): Validation
   // Check for disconnected processing nodes
   const targetIds = new Set(edges.map(e => e.target))
   const sourceIds = new Set(edges.map(e => e.source))
+  const nodeMap = new Map(nodes.map(n => [n.id, n]))
 
   for (const node of nodes) {
     if (node.type === 'input' && !sourceIds.has(node.id)) {
@@ -94,12 +96,57 @@ export function validatePipeline(nodes: NodeDef[], edges: EdgeDef[]): Validation
     }
   }
 
+  // Check handle data type compatibility
+  for (const edge of edges) {
+    const srcNode = nodeMap.get(edge.source)
+    const tgtNode = nodeMap.get(edge.target)
+    if (!srcNode || !tgtNode) continue
+
+    const srcDefs = getHandleDefs(srcNode.type as NodeType)
+    const tgtDefs = getHandleDefs(tgtNode.type as NodeType)
+
+    const srcHandle = srcDefs.sources.find(h => h.id === edge.sourceHandle)
+    const tgtHandle = tgtDefs.targets.find(h => h.id === edge.targetHandle)
+
+    if (srcHandle && tgtHandle && srcHandle.dataType !== tgtHandle.dataType) {
+      errors.push({
+        message: `Incompatible connection: ${srcNode.type}.${edge.sourceHandle} (${srcHandle.dataType}) → ${tgtNode.type}.${edge.targetHandle} (${tgtHandle.dataType})`,
+      })
+    }
+  }
+
+  // Check multi-connection constraints: non-multi target handles should have at most 1 connection
+  const targetHandleCount = new Map<string, number>()
+  for (const edge of edges) {
+    const key = `${edge.target}:${edge.targetHandle}`
+    targetHandleCount.set(key, (targetHandleCount.get(key) || 0) + 1)
+  }
+  for (const [key, count] of targetHandleCount) {
+    if (count <= 1) continue
+    const [nodeId, handleId] = key.split(':')
+    const node = nodeMap.get(nodeId)
+    if (!node) continue
+    const defs = getHandleDefs(node.type as NodeType)
+    const handleDef = defs.targets.find(h => h.id === handleId)
+    if (handleDef && !handleDef.multi) {
+      errors.push({
+        nodeId,
+        message: `Handle "${handleId}" on node "${nodeId}" does not accept multiple connections`,
+      })
+    }
+  }
+
   return errors
 }
 
 /** Get upstream node IDs for a given node. */
 export function getUpstreamNodes(nodeId: string, edges: EdgeDef[]): string[] {
   return edges.filter(e => e.target === nodeId).map(e => e.source)
+}
+
+/** Get all edges targeting a given node. */
+export function getUpstreamEdges(nodeId: string, edges: EdgeDef[]): EdgeDef[] {
+  return edges.filter(e => e.target === nodeId)
 }
 
 /** Get all downstream node IDs (transitive) for a given node. */

--- a/packages/runtime/src/utils/graph.ts
+++ b/packages/runtime/src/utils/graph.ts
@@ -81,7 +81,8 @@ export function validatePipeline(nodes: NodeDef[], edges: EdgeDef[]): Validation
 
   for (const node of nodes) {
     if (node.type === 'input' && !sourceIds.has(node.id)) {
-      errors.push({ nodeId: node.id, message: `Input node "${node.id}" has no outgoing connection` })
+      // Unconnected input nodes are OK — just skip them during execution
+      continue
     }
     if (node.type === 'output' && !targetIds.has(node.id)) {
       errors.push({ nodeId: node.id, message: `Output node "${node.id}" has no incoming connection` })

--- a/packages/runtime/src/utils/hash.ts
+++ b/packages/runtime/src/utils/hash.ts
@@ -1,7 +1,17 @@
 /** Create a deterministic cache key from params and input revisions. */
-export function computeCacheKey(nodeId: string, params: Record<string, unknown>, inputRevisions: number[]): string {
+export function computeCacheKey(
+  nodeId: string,
+  params: Record<string, unknown>,
+  inputRevisions: number[] | Record<string, number[]>,
+): string {
   const paramsStr = JSON.stringify(params, Object.keys(params).sort())
-  const inputStr = inputRevisions.join(',')
+  let inputStr: string
+  if (Array.isArray(inputRevisions)) {
+    inputStr = inputRevisions.join(',')
+  } else {
+    const keys = Object.keys(inputRevisions).sort()
+    inputStr = keys.map(k => `${k}:${inputRevisions[k].join(',')}`).join(';')
+  }
   return `${nodeId}:${simpleHash(paramsStr)}:${simpleHash(inputStr)}`
 }
 

--- a/shared/types/execution.ts
+++ b/shared/types/execution.ts
@@ -2,13 +2,18 @@ import type { ImageFrame } from './image-frame'
 
 export type NodeStatus = 'idle' | 'pending' | 'running' | 'done' | 'error' | 'cached'
 
+export interface NodeOutput {
+  asset: ImageFrame
+  [key: string]: ImageFrame | unknown
+}
+
 export interface NodeState {
   status: NodeStatus
   progress: number
   statusMessage: string | null
   downloadProgress: number | null
   error: string | null
-  output: ImageFrame | null
+  output: NodeOutput | null
   cacheKey: string | null
   deviceUsed?: 'webgpu' | 'wasm' | null
 }

--- a/shared/types/node-params.ts
+++ b/shared/types/node-params.ts
@@ -41,6 +41,13 @@ export interface FaceParseParams {
   device: 'webgpu' | 'wasm' | 'auto'
 }
 
+export interface SpritesheetParams {
+  columns: number | 'auto'
+  rows: number | 'auto'
+  gap: number
+  bgColor: string
+}
+
 export type NodeParamsMap = {
   'input': InputNodeParams
   'output': OutputNodeParams
@@ -50,6 +57,7 @@ export type NodeParamsMap = {
   'outline': OutlineParams
   'depth': DepthParams
   'face-parse': FaceParseParams
+  'spritesheet': SpritesheetParams
 }
 
 export const DEFAULT_PARAMS: NodeParamsMap = {
@@ -61,4 +69,5 @@ export const DEFAULT_PARAMS: NodeParamsMap = {
   'outline': { thickness: 4, color: '#ffffff', opacity: 1, quality: 'medium', position: 'outside', threshold: 0 },
   'depth': { model: 'fast', device: 'auto' },
   'face-parse': { device: 'auto' },
+  'spritesheet': { columns: 'auto', rows: 'auto', gap: 0, bgColor: 'transparent' },
 }

--- a/shared/types/pipeline.ts
+++ b/shared/types/pipeline.ts
@@ -1,4 +1,4 @@
-export type NodeType = 'input' | 'output' | 'remove-bg' | 'normalize' | 'upscale' | 'outline' | 'depth' | 'face-parse'
+export type NodeType = 'input' | 'output' | 'remove-bg' | 'normalize' | 'upscale' | 'outline' | 'depth' | 'face-parse' | 'spritesheet'
 
 export interface NodePosition {
   x: number
@@ -22,7 +22,7 @@ export interface EdgeDef {
 }
 
 export interface PipelineDefinition {
-  version: 1
+  version: 1 | 2
   nodes: NodeDef[]
   edges: EdgeDef[]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -312,24 +312,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@clack/core@npm:1.0.1":
-  version: 1.0.1
-  resolution: "@clack/core@npm:1.0.1"
+"@clack/core@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@clack/core@npm:1.0.0"
   dependencies:
     picocolors: "npm:^1.0.0"
     sisteransi: "npm:^1.0.5"
-  checksum: 10c0/12c3feb2fc2afe69b09c9a15fc51be1bbc1d2781ed72ca4e251aaf2bcc50f66e38879f49c9bb522a4ac09135d2b2b887991bd83195600164ddd13168018b36ac
+  checksum: 10c0/01c90ccb7e78fd1dd14f5081e6299a2eb3a02d4cda22d9996d572342261ed4f8e5e7e62d9df936673c1570e37b932cd4c2f737b9fe4a8973ac546d8d94c683a0
   languageName: node
   linkType: hard
 
 "@clack/prompts@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "@clack/prompts@npm:1.0.1"
+  version: 1.0.0
+  resolution: "@clack/prompts@npm:1.0.0"
   dependencies:
-    "@clack/core": "npm:1.0.1"
+    "@clack/core": "npm:1.0.0"
     picocolors: "npm:^1.0.0"
     sisteransi: "npm:^1.0.5"
-  checksum: 10c0/05e2dcf63abdc2dee1b12df5b491c1b8bbeb9d3903ae5e46b7d4fb3997881d0c25bc7ef10cb9d0fc0229af1cb9d72d4ddc414f053882fd5ed5b6fd6121334ee8
+  checksum: 10c0/6c770c1fff44b6b46c282b89b06455cb4ac0a9988ddb1dd65c8693550beceea7dbf1729a6f1b77137897c9a7aa7d5eda3a341141f65939d1d1453c7b42600d5f
   languageName: node
   linkType: hard
 
@@ -1494,14 +1494,14 @@ __metadata:
   linkType: hard
 
 "@nuxtjs/plausible@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "@nuxtjs/plausible@npm:3.0.1"
+  version: 3.0.0
+  resolution: "@nuxtjs/plausible@npm:3.0.0"
   dependencies:
     "@nuxt/kit": "npm:^4.3.1"
     "@plausible-analytics/tracker": "npm:^0.4.4"
     defu: "npm:^6.1.4"
     ufo: "npm:^1.6.3"
-  checksum: 10c0/804267d0a8e4fc4bc662c61e6739c697402ad1b06c40a9053467176e4f716780a31a469b4add3affd8f715152ba0479bd44bb3ef6d170206c106d753f82c38c2
+  checksum: 10c0/08e4e56971c01b4b5efa514f80143824a55fd8847ac10319be2e6734f9f425a5adb91f62c478f446aec4f1e2bc4466f69ac7106600edd6b672e72d6713568dbe
   languageName: node
   linkType: hard
 
@@ -3377,14 +3377,14 @@ __metadata:
   linkType: hard
 
 "b4a@npm:^1.6.4":
-  version: 1.7.5
-  resolution: "b4a@npm:1.7.5"
+  version: 1.7.3
+  resolution: "b4a@npm:1.7.3"
   peerDependencies:
     react-native-b4a: "*"
   peerDependenciesMeta:
     react-native-b4a:
       optional: true
-  checksum: 10c0/2e7fe86b4186d5906168d785c108882b083a7b808efa13c4c41ab974d1376da927e0a6b45ca392ac50731cc6a08fedc5200ff5f9957b1ac86b2b1beaa6acead5
+  checksum: 10c0/ac16d186e00fa0d16de1f1a4af413953bc762d50d5a0e382aaa744a13886600313b7293403ad77fc83f6b1489c3fc2610494d1026754a51d1b7cdac2115a7598
   languageName: node
   linkType: hard
 
@@ -3619,9 +3619,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001759, caniuse-lite@npm:^1.0.30001766":
-  version: 1.0.30001770
-  resolution: "caniuse-lite@npm:1.0.30001770"
-  checksum: 10c0/02d15a8b723af65318cb4d888a52bb090076898da7b0de99e8676d537f8d1d2ae4797e81518e1e30cbfe84c33b048c322e8bfafc5b23cfee8defb0d2bf271149
+  version: 1.0.30001769
+  resolution: "caniuse-lite@npm:1.0.30001769"
+  checksum: 10c0/161b8c30ab967371807d45d361f0d5bc06e38ef2dbf811493d70cd97c21e1522f5b91fd944c419a00047ee09c931ca64627f125a9ffa7a17a9fdff8dad9765b0
   languageName: node
   linkType: hard
 
@@ -4326,9 +4326,9 @@ __metadata:
   linkType: hard
 
 "dotenv@npm:^17.2.3":
-  version: 17.3.1
-  resolution: "dotenv@npm:17.3.1"
-  checksum: 10c0/c78e0c2d5a549c751e544cc60e2b95e7cb67e0c551f42e094d161c6b297aa44b630a3c2dcacf5569e529a6c2a6b84e2ab9be8d37b299d425df5a18b81ce4a35f
+  version: 17.2.4
+  resolution: "dotenv@npm:17.2.4"
+  checksum: 10c0/901aeee9cb40860291bdb452f6ca66aada78438331a026b0bd86fd41b94a79752dbc6a8971f4f26e6cafef11b4a27bb12ea99c0cbe7dfa61791f194727f799e5
   languageName: node
   linkType: hard
 
@@ -4999,13 +4999,13 @@ __metadata:
   linkType: hard
 
 "glob@npm:^13.0.0":
-  version: 13.0.4
-  resolution: "glob@npm:13.0.4"
+  version: 13.0.3
+  resolution: "glob@npm:13.0.3"
   dependencies:
-    minimatch: "npm:^10.2.1"
+    minimatch: "npm:^10.2.0"
     minipass: "npm:^7.1.2"
     path-scurry: "npm:^2.0.0"
-  checksum: 10c0/cf380e68f5c64ab8c52f977c74b7e9affb3d589cfbf663f89baa681468abe97508043be549562f7c4b3f4088ac298902321af9d4ba8e42762bac041add0fed47
+  checksum: 10c0/333dc5c40ca0e50400465d8f5c45aa7cdd32580c4d1a4c502dfb4fb9c469a936b8e0c6bbd09cd6353fd05982e48d7f79e819159a36fb3e0a41ee722607bc11a9
   languageName: node
   linkType: hard
 
@@ -5439,11 +5439,11 @@ __metadata:
   linkType: hard
 
 "is-wsl@npm:^3.1.0":
-  version: 3.1.1
-  resolution: "is-wsl@npm:3.1.1"
+  version: 3.1.0
+  resolution: "is-wsl@npm:3.1.0"
   dependencies:
     is-inside-container: "npm:^1.0.0"
-  checksum: 10c0/7e5023522bfb8f27de4de960b0d82c4a8146c0bddb186529a3616d78b5bbbfc19ef0c5fc60d0b3a3cc0bf95a415fbdedc18454310ea3049587c879b07ace5107
+  checksum: 10c0/d3317c11995690a32c362100225e22ba793678fe8732660c6de511ae71a0ff05b06980cf21f98a6bf40d7be0e9e9506f859abe00a1118287d63e53d0a3d06947
   languageName: node
   linkType: hard
 
@@ -5996,12 +5996,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.2.1":
-  version: 10.2.1
-  resolution: "minimatch@npm:10.2.1"
+"minimatch@npm:^10.2.0":
+  version: 10.2.0
+  resolution: "minimatch@npm:10.2.0"
   dependencies:
     brace-expansion: "npm:^5.0.2"
-  checksum: 10c0/86c3ed013630e820fda00336ee786a03098723b60bfae452de6306708fc83619df40a99dc6ec59c97d14e25b3b3371669a04e5bf508b1b00339b20229c4907d2
+  checksum: 10c0/256e72812bb99a86cdc788bf46a4da3f6e139db9123e20ed85a6795b93fdc0b76468ac511eb5535a023adb02a53fd598f971e990d0ca3bd6de6d41ea0199def1
   languageName: node
   linkType: hard
 
@@ -8101,13 +8101,13 @@ __metadata:
   linkType: hard
 
 "simple-git@npm:^3.30.0":
-  version: 3.31.1
-  resolution: "simple-git@npm:3.31.1"
+  version: 3.30.0
+  resolution: "simple-git@npm:3.30.0"
   dependencies:
     "@kwsites/file-exists": "npm:^1.1.1"
     "@kwsites/promise-deferred": "npm:^1.1.1"
     debug: "npm:^4.4.0"
-  checksum: 10c0/8082ef7b3356e0ab01726aa6f614d2e04b6bcf0edf0949e184c49eeb546cb2c903347614a054c7da77021ddd869d52d952d9dab008c6986f614a1d91f16d0041
+  checksum: 10c0/ca123580944d55c7f93d17f7a89b39cd43245916b35ed3a8b1269d1f2ae9200e17f098e42af4a2572313726f1273641cbe0748a1ea37d8c803c181fb69068b1d
   languageName: node
   linkType: hard
 
@@ -8217,11 +8217,11 @@ __metadata:
   linkType: hard
 
 "srvx@npm:^0.11.2":
-  version: 0.11.5
-  resolution: "srvx@npm:0.11.5"
+  version: 0.11.4
+  resolution: "srvx@npm:0.11.4"
   bin:
     srvx: bin/srvx.mjs
-  checksum: 10c0/b0f613b9484d9f3683246e76312f1c6219ecaf870daeb420242cd9610279935b5e44f313eb9484d13147e53d886830a9bd80d63d17b63b651f64f6c5282c7832
+  checksum: 10c0/a7e537df90be41f3e5b29a0202472619b7a8908bb5410df9460854a340d569f93a6019b3d4cdb27163bfd0c475c3cc47fb373247aa579cf854b7cc491d903636
   languageName: node
   linkType: hard
 
@@ -8474,7 +8474,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.0.1, tar@npm:^7.4.0, tar@npm:^7.5.4":
+"tar@npm:^7.0.1, tar@npm:^7.4.0":
+  version: 7.5.7
+  resolution: "tar@npm:7.5.7"
+  dependencies:
+    "@isaacs/fs-minipass": "npm:^4.0.0"
+    chownr: "npm:^3.0.0"
+    minipass: "npm:^7.1.2"
+    minizlib: "npm:^3.1.0"
+    yallist: "npm:^5.0.0"
+  checksum: 10c0/51f261afc437e1112c3e7919478d6176ea83f7f7727864d8c2cce10f0b03a631d1911644a567348c3063c45abdae39718ba97abb073d22aa3538b9a53ae1e31c
+  languageName: node
+  linkType: hard
+
+"tar@npm:^7.5.4":
   version: 7.5.9
   resolution: "tar@npm:7.5.9"
   dependencies:
@@ -8502,11 +8515,11 @@ __metadata:
   linkType: hard
 
 "text-decoder@npm:^1.1.0":
-  version: 1.2.7
-  resolution: "text-decoder@npm:1.2.7"
+  version: 1.2.3
+  resolution: "text-decoder@npm:1.2.3"
   dependencies:
     b4a: "npm:^1.6.4"
-  checksum: 10c0/929938ed154fbadb660a7f3d1aca30b7e53649a731af7583168fcfba0c158046325d35d945926e2a512bb62d1a49a7818151c987ea38b48853f01e1615722fc5
+  checksum: 10c0/569d776b9250158681c83656ef2c3e0a5d5c660c27ca69f87eedef921749a4fbf02095e5f9a0f862a25cf35258379b06e31dee9c125c9f72e273b7ca1a6d1977
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

<img width="1196" height="880" alt="image" src="https://github.com/user-attachments/assets/733a02ee-8be6-4f15-8cf1-06c7265e5ce5" />

## Summary
- **Named handles & multi-input/output**: Nodes now support named, typed handles with multi-connection targets (e.g. spritesheet node accepts multiple inputs)
- **Spritesheet node**: New node that composites multiple input images into a grid spritesheet
- **Canvas UX**: Context menus for nodes/edges, multi-select with Shift+click/drag, Backspace to delete, cleaner node chrome
- **Multi-file drop**: Drag multiple images onto the canvas to bulk-fill existing input nodes and auto-create new ones for overflow
- **Pipeline validation**: Allow unconnected input nodes so partial pipelines are valid

## Todo
- [] Spritesheet should try to fill each cell as much as possible

## Test plan
- [ ] Add spritesheet node, connect multiple inputs, verify grid output
- [ ] Right-click nodes and edges to see context menus, delete from menu
- [ ] Shift+click and Shift+drag to multi-select nodes, press Delete/Backspace to remove
- [ ] Drag multiple image files onto the canvas — verify existing inputs fill first, overflow creates new input nodes
- [ ] Drop a single file directly on an InputNode — verify existing behavior still works
- [ ] Verify non-image files are ignored when dropped on canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)